### PR TITLE
Set Activity as default dashboard tab

### DIFF
--- a/src/app/auth/github/callback/route.ts
+++ b/src/app/auth/github/callback/route.ts
@@ -38,7 +38,7 @@ function clearTransientOAuthCookies(response: NextResponse) {
 function resolveReturnPath(request: NextRequest) {
   const stored = request.cookies.get(GITHUB_RETURN_COOKIE)?.value ?? null;
   if (!stored || !stored.startsWith("/") || stored.startsWith("//")) {
-    return "/dashboard";
+    return "/dashboard/activity";
   }
 
   return stored;

--- a/src/app/dashboard/(tabs)/layout.tsx
+++ b/src/app/dashboard/(tabs)/layout.tsx
@@ -11,7 +11,7 @@ export default async function DashboardTabsLayout({
   const session = await readActiveSession();
 
   if (!session) {
-    redirect("/auth/github?next=/dashboard");
+    redirect("/auth/github?next=/dashboard/activity");
   }
 
   return (

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,6 +4,6 @@ import { redirect } from "next/navigation";
 export const dynamic = "force-dynamic";
 
 export default function DashboardPage() {
-  const analyticsRoute = "/dashboard/analytics" as Route;
-  redirect(analyticsRoute);
+  const activityRoute = "/dashboard/activity" as Route;
+  redirect(activityRoute);
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -50,7 +50,9 @@ export default function Home() {
             size="lg"
             className="bg-blue-500 text-white shadow-lg shadow-blue-900/40 hover:bg-blue-400"
           >
-            <Link href="/auth/github?next=/dashboard">GitHub으로 로그인</Link>
+            <Link href="/auth/github?next=/dashboard/activity">
+              GitHub으로 로그인
+            </Link>
           </Button>
         </div>
       </section>

--- a/src/components/test-harness/dashboard-tabs-harness.tsx
+++ b/src/components/test-harness/dashboard-tabs-harness.tsx
@@ -11,7 +11,7 @@ type DashboardTabsHarnessProps = {
 };
 
 export function DashboardTabsHarness({
-  initialPathname = "/dashboard/analytics",
+  initialPathname = "/dashboard/activity",
 }: DashboardTabsHarnessProps) {
   const [pathname, setPathname] = useState(initialPathname);
 

--- a/tests/e2e/dashboard-tabs.spec.ts
+++ b/tests/e2e/dashboard-tabs.spec.ts
@@ -11,20 +11,22 @@ test.describe("Dashboard navigation (Playwright)", () => {
     await expect(page).toHaveURL(/https:\/\/github\.com\/login/);
   });
 
-  test("redirects /dashboard to /dashboard/analytics", async ({ page }) => {
+  test("redirects /dashboard to /dashboard/activity", async ({ page }) => {
     await page.goto("/test-harness/auth/session?userId=e2e-user");
     await page.goto(DASHBOARD_ROOT);
-    await expect(page).toHaveURL(/\/dashboard\/analytics$/);
+    await expect(page).toHaveURL(/\/dashboard\/activity$/);
   });
 
   test("highlights active tab and updates on navigation", async ({ page }) => {
     await page.goto(DASHBOARD_TABS_PATH);
 
     const currentPath = page.getByTestId("current-path");
-    await expect(currentPath).toContainText("/dashboard/analytics");
+    await expect(currentPath).toContainText("/dashboard/activity");
 
+    const activityTab = page.getByRole("link", { name: "Activity" });
+    await expect(activityTab).toHaveClass(/text-primary/);
     const analyticsTab = page.getByRole("link", { name: "Analytics" });
-    await expect(analyticsTab).toHaveClass(/text-primary/);
+    await expect(analyticsTab).toHaveAttribute("href", "/dashboard/analytics");
     const peopleTab = page.getByRole("link", { name: "People" });
     await expect(peopleTab).toHaveAttribute("href", "/dashboard/people");
 


### PR DESCRIPTION
Update redirects, sign-in flow, harness, and Playwright tests to land users on Activity.