### PR TITLE
Capture PR-Issue links

### DIFF
--- a/scripts/run-db-tests.mjs
+++ b/scripts/run-db-tests.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import process from "node:process";
+
+async function canStartTestcontainer() {
+  const explicitUrl =
+    process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL ?? null;
+  if (explicitUrl) {
+    return true;
+  }
+
+  const { PostgreSqlContainer } = await import("@testcontainers/postgresql");
+  try {
+    const container = await new PostgreSqlContainer("postgres:16")
+      .withReuse()
+      .start();
+    await container.stop();
+    return true;
+  } catch (error) {
+    const hint =
+      "[test:db] Skipping database-backed tests: PostgreSQL container unavailable.";
+    const detail =
+      error instanceof Error ? error.message : JSON.stringify(error);
+    console.warn(`${hint}\n${detail}`);
+    return false;
+  }
+}
+
+async function runVitest() {
+  const runner = process.platform === "win32" ? "npx.cmd" : "npx";
+  const child = spawn(runner, [
+    "vitest",
+    "run",
+    "--config",
+    "vitest.db.config.ts",
+  ], {
+    stdio: "inherit",
+    env: process.env,
+    cwd: process.cwd(),
+  });
+
+  child.on("exit", (code) => {
+    process.exit(code ?? 1);
+  });
+}
+
+const available = await canStartTestcontainer();
+if (!available) {
+  process.exit(0);
+}
+
+await runVitest();

--- a/src/app/api/sync/pr-link-backfill/route.test.ts
+++ b/src/app/api/sync/pr-link-backfill/route.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST } from "@/app/api/sync/pr-link-backfill/route";
+import { readActiveSession } from "@/lib/auth/session";
+import { runPrLinkBackfill } from "@/lib/sync/service";
+
+vi.mock("@/lib/sync/service", () => ({
+  runPrLinkBackfill: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  readActiveSession: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(readActiveSession).mockResolvedValue({
+    id: "session",
+    userId: "user",
+    orgSlug: "org",
+    orgVerified: true,
+    isAdmin: true,
+    createdAt: new Date(),
+    lastSeenAt: new Date(),
+    expiresAt: new Date(Date.now() + 60_000),
+  });
+});
+
+describe("POST /api/sync/pr-link-backfill", () => {
+  it("runs PR link backfill and returns the result", async () => {
+    const report = {
+      startDate: "2024-04-01T00:00:00.000Z",
+      startedAt: "2024-05-01T12:00:00.000Z",
+      completedAt: "2024-05-01T12:01:00.000Z",
+      repositoriesProcessed: 2,
+      pullRequestCount: 5,
+      latestPullRequestUpdated: "2024-04-15T00:00:00.000Z",
+    };
+    vi.mocked(runPrLinkBackfill).mockResolvedValueOnce(report as never);
+
+    const response = await POST(
+      new Request("http://localhost/api/sync/pr-link-backfill", {
+        method: "POST",
+        body: JSON.stringify({ startDate: "2024-04-01" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({ success: true, result: report });
+    expect(runPrLinkBackfill).toHaveBeenCalledWith(
+      "2024-04-01",
+      undefined,
+      expect.any(Function),
+    );
+  });
+
+  it("passes an end date when provided", async () => {
+    vi.mocked(runPrLinkBackfill).mockResolvedValueOnce({} as never);
+
+    await POST(
+      new Request("http://localhost/api/sync/pr-link-backfill", {
+        method: "POST",
+        body: JSON.stringify({
+          startDate: "2024-04-01",
+          endDate: "2024-04-05",
+        }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    expect(runPrLinkBackfill).toHaveBeenCalledWith(
+      "2024-04-01",
+      "2024-04-05",
+      expect.any(Function),
+    );
+  });
+
+  it("returns validation errors for invalid payload", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/sync/pr-link-backfill", {
+        method: "POST",
+        body: JSON.stringify({}),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.success).toBe(false);
+    expect(runPrLinkBackfill).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 if runPrLinkBackfill throws a known error", async () => {
+    vi.mocked(runPrLinkBackfill).mockRejectedValueOnce(
+      new Error("Backfill failure"),
+    );
+
+    const response = await POST(
+      new Request("http://localhost/api/sync/pr-link-backfill", {
+        method: "POST",
+        body: JSON.stringify({ startDate: "2024-04-01" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body).toEqual({ success: false, message: "Backfill failure" });
+  });
+
+  it("returns 500 if runPrLinkBackfill throws a non-error value", async () => {
+    vi.mocked(runPrLinkBackfill).mockRejectedValueOnce("boom");
+
+    const response = await POST(
+      new Request("http://localhost/api/sync/pr-link-backfill", {
+        method: "POST",
+        body: JSON.stringify({ startDate: "2024-04-01" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body).toEqual({
+      success: false,
+      message: "Unexpected error during PR link backfill.",
+    });
+  });
+
+  it("returns 401 when the user is not authenticated", async () => {
+    vi.mocked(readActiveSession).mockResolvedValueOnce(null);
+
+    const response = await POST(
+      new Request("http://localhost/api/sync/pr-link-backfill", {
+        method: "POST",
+        body: JSON.stringify({ startDate: "2024-04-01" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      success: false,
+      message: "Authentication required.",
+    });
+    expect(runPrLinkBackfill).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the user is not an administrator", async () => {
+    vi.mocked(readActiveSession).mockResolvedValueOnce({
+      id: "session",
+      userId: "user",
+      orgSlug: "org",
+      orgVerified: true,
+      isAdmin: false,
+      createdAt: new Date(),
+      lastSeenAt: new Date(),
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    const response = await POST(
+      new Request("http://localhost/api/sync/pr-link-backfill", {
+        method: "POST",
+        body: JSON.stringify({ startDate: "2024-04-01" }),
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      success: false,
+      message: "Administrator access is required to manage sync operations.",
+    });
+    expect(runPrLinkBackfill).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/sync/pr-link-backfill/route.ts
+++ b/src/app/api/sync/pr-link-backfill/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { readActiveSession } from "@/lib/auth/session";
+import { runPrLinkBackfill } from "@/lib/sync/service";
+
+const schema = z.object({
+  startDate: z.string(),
+  endDate: z.string().optional(),
+});
+
+function buildLogger(prefix: string) {
+  return (message: string) => {
+    const timestamp = new Date().toISOString();
+    console.log(`[${timestamp}] [${prefix}] ${message}`);
+  };
+}
+
+export async function POST(request: Request) {
+  try {
+    const session = await readActiveSession();
+    if (!session) {
+      return NextResponse.json(
+        { success: false, message: "Authentication required." },
+        { status: 401 },
+      );
+    }
+
+    if (!session.isAdmin) {
+      return NextResponse.json(
+        {
+          success: false,
+          message:
+            "Administrator access is required to manage sync operations.",
+        },
+        { status: 403 },
+      );
+    }
+
+    const payload = schema.parse(await request.json());
+    const result = await runPrLinkBackfill(
+      payload.startDate,
+      payload.endDate,
+      buildLogger("pr-link-backfill"),
+    );
+
+    return NextResponse.json({
+      success: true,
+      result,
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: "Invalid request payload.",
+          issues: error.issues,
+        },
+        { status: 400 },
+      );
+    }
+
+    if (error instanceof Error) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: error.message,
+        },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: false,
+        message: "Unexpected error during PR link backfill.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/dashboard/sync-controls.tsx
+++ b/src/components/dashboard/sync-controls.tsx
@@ -18,7 +18,11 @@ import {
   formatDateTime as formatDateTimeDisplay,
   normalizeDateTimeDisplayFormat,
 } from "@/lib/date-time-format";
-import type { BackfillResult, SyncStatus } from "@/lib/sync/service";
+import type {
+  BackfillResult,
+  PrLinkBackfillResult,
+  SyncStatus,
+} from "@/lib/sync/service";
 
 type SyncControlsProps = {
   status: SyncStatus;
@@ -267,10 +271,15 @@ export function SyncControls({ status, isAdmin }: SyncControlsProps) {
     now.setMonth(now.getMonth() - 1);
     return now.toISOString().slice(0, 10);
   });
+  const prLinkBackfillInputId = useId();
+  const prLinkBackfillEndInputId = useId();
+  const [prLinkStartDate, setPrLinkStartDate] = useState(() => backfillDate);
+  const [prLinkEndDate, setPrLinkEndDate] = useState("");
   const [feedback, setFeedback] = useState<string | null>(null);
   const [backfillHistory, setBackfillHistory] = useState<BackfillResult[]>([]);
 
   const [isRunningBackfill, setIsRunningBackfill] = useState(false);
+  const [isRunningPrLinkBackfill, setIsRunningPrLinkBackfill] = useState(false);
   const [isTogglingAuto, setIsTogglingAuto] = useState(false);
   const [isResetting, setIsResetting] = useState(false);
   const [isCleaning, setIsCleaning] = useState(false);
@@ -423,7 +432,6 @@ export function SyncControls({ status, isAdmin }: SyncControlsProps) {
       } else {
         setFeedback("백필이 성공적으로 실행되었습니다.");
       }
-      router.refresh();
     } catch (error) {
       setFeedback(
         error instanceof Error ? error.message : "백필 중 오류가 발생했습니다.",
@@ -569,6 +577,55 @@ export function SyncControls({ status, isAdmin }: SyncControlsProps) {
     }
   }
 
+  async function handlePrLinkBackfill() {
+    if (!canManageSync) {
+      setFeedback(ADMIN_ONLY_MESSAGE);
+      return;
+    }
+
+    if (!prLinkStartDate) {
+      setFeedback("PR 링크 백필 시작 날짜를 선택하세요.");
+      return;
+    }
+
+    if (prLinkEndDate && prLinkEndDate < prLinkStartDate) {
+      setFeedback(
+        "PR 링크 백필 종료 날짜는 시작 날짜와 같거나 이후여야 합니다.",
+      );
+      return;
+    }
+
+    setIsRunningPrLinkBackfill(true);
+    try {
+      const response = await fetch("/api/sync/pr-link-backfill", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          startDate: prLinkStartDate,
+          ...(prLinkEndDate ? { endDate: prLinkEndDate } : {}),
+        }),
+      });
+      const data = await parseApiResponse<PrLinkBackfillResult>(response);
+      if (!data.success) {
+        throw new Error(data.message ?? "PR 링크 백필 실행에 실패했습니다.");
+      }
+
+      setFeedback(
+        "PR 링크 백필을 요청했습니다. 진행 상황은 동기화 로그에서 확인하세요.",
+      );
+    } catch (error) {
+      setFeedback(
+        error instanceof Error
+          ? error.message
+          : "PR 링크 백필 중 오류가 발생했습니다.",
+      );
+    } finally {
+      setIsRunningPrLinkBackfill(false);
+    }
+  }
+
   return (
     <section className="flex flex-col gap-3">
       <header className="flex flex-col gap-1">
@@ -611,6 +668,53 @@ export function SyncControls({ status, isAdmin }: SyncControlsProps) {
               title={!canManageSync ? ADMIN_ONLY_MESSAGE : undefined}
             >
               {isRunningBackfill ? "백필 실행 중..." : "백필 실행"}
+            </Button>
+          </CardFooter>
+        </Card>
+
+        <Card className="border-border/70">
+          <CardHeader>
+            <CardTitle>PR 링크 백필 (임시)</CardTitle>
+            <CardDescription>
+              지정한 날짜 이후의 PR을 다시 수집해 연결된 이슈 정보를 갱신합니다.
+              실행 결과는 동기화 히스토리에서 확인하세요.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4">
+            <label
+              className="flex flex-col gap-2 text-sm"
+              htmlFor={prLinkBackfillInputId}
+            >
+              <span className="text-muted-foreground">시작 날짜</span>
+              <Input
+                id={prLinkBackfillInputId}
+                value={prLinkStartDate}
+                onChange={(event) => setPrLinkStartDate(event.target.value)}
+                type="date"
+              />
+            </label>
+            <label
+              className="flex flex-col gap-2 text-sm"
+              htmlFor={prLinkBackfillEndInputId}
+            >
+              <span className="text-muted-foreground">종료 날짜 (선택)</span>
+              <Input
+                id={prLinkBackfillEndInputId}
+                value={prLinkEndDate}
+                onChange={(event) => setPrLinkEndDate(event.target.value)}
+                type="date"
+              />
+            </label>
+          </CardContent>
+          <CardFooter>
+            <Button
+              onClick={handlePrLinkBackfill}
+              disabled={isRunningPrLinkBackfill || !canManageSync}
+              title={!canManageSync ? ADMIN_ONLY_MESSAGE : undefined}
+            >
+              {isRunningPrLinkBackfill
+                ? "PR 링크 백필 실행 중..."
+                : "PR 링크 백필 실행"}
             </Button>
           </CardFooter>
         </Card>

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -82,6 +82,19 @@ const SCHEMA_STATEMENTS = [
   `CREATE INDEX IF NOT EXISTS pull_requests_author_idx ON pull_requests(author_id)`,
   `CREATE INDEX IF NOT EXISTS pull_requests_created_idx ON pull_requests(github_created_at)`,
   `CREATE INDEX IF NOT EXISTS pull_requests_updated_idx ON pull_requests(github_updated_at)`,
+  `CREATE TABLE IF NOT EXISTS pull_request_issues (
+    pull_request_id TEXT NOT NULL REFERENCES pull_requests(id) ON DELETE CASCADE,
+    issue_id TEXT NOT NULL,
+    issue_number INTEGER,
+    issue_title TEXT,
+    issue_state TEXT,
+    issue_url TEXT,
+    issue_repository TEXT,
+    inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (pull_request_id, issue_id)
+  )`,
+  `CREATE INDEX IF NOT EXISTS pull_request_issues_issue_idx ON pull_request_issues(issue_id)`,
   `CREATE TABLE IF NOT EXISTS reviews (
     id TEXT PRIMARY KEY,
     pull_request_id TEXT NOT NULL REFERENCES pull_requests(id) ON DELETE CASCADE,

--- a/src/lib/github/collectors.test.ts
+++ b/src/lib/github/collectors.test.ts
@@ -25,6 +25,7 @@ const {
   upsertUserMock,
   upsertIssueMock,
   upsertPullRequestMock,
+  replacePullRequestIssuesMock,
   upsertReviewMock,
   upsertReviewRequestMock,
   upsertCommentMock,
@@ -47,6 +48,7 @@ const {
     upsertUserMock: vi.fn(async () => {}),
     upsertIssueMock: vi.fn(async () => {}),
     upsertPullRequestMock: vi.fn(async () => {}),
+    replacePullRequestIssuesMock: vi.fn(async () => {}),
     upsertReviewMock: vi.fn(async () => {}),
     upsertReviewRequestMock: vi.fn(async () => {}),
     upsertCommentMock: vi.fn(async () => {}),
@@ -79,6 +81,9 @@ vi.mock("@/lib/db/operations", () => ({
     upsertIssueMock(...args),
   upsertPullRequest: (...args: Parameters<typeof upsertPullRequestMock>) =>
     upsertPullRequestMock(...args),
+  replacePullRequestIssues: (
+    ...args: Parameters<typeof replacePullRequestIssuesMock>
+  ) => replacePullRequestIssuesMock(...args),
   upsertReview: (...args: Parameters<typeof upsertReviewMock>) =>
     upsertReviewMock(...args),
   upsertReviewRequest: (...args: Parameters<typeof upsertReviewRequestMock>) =>

--- a/src/lib/github/queries.ts
+++ b/src/lib/github/queries.ts
@@ -485,6 +485,18 @@ export const repositoryPullRequestsQuery = gql`
               color
             }
           }
+          closingIssuesReferences(first: 20) {
+            nodes {
+              id
+              number
+              title
+              url
+              state
+              repository {
+                nameWithOwner
+              }
+            }
+          }
           timelineItems(last: 50, itemTypes: [REVIEW_REQUESTED_EVENT, REVIEW_REQUEST_REMOVED_EVENT]) {
             nodes {
               __typename
@@ -540,6 +552,91 @@ export const repositoryPullRequestsQuery = gql`
                 login
                 name
                 avatarUrl(size: 200)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const repositoryPullRequestLinksQuery = gql`
+  query RepositoryPullRequestLinks($owner: String!, $name: String!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+      pullRequests(first: 25, after: $cursor, orderBy: { field: UPDATED_AT, direction: ASC }) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          number
+          title
+          state
+          url
+          createdAt
+          updatedAt
+          closedAt
+          mergedAt
+          merged
+          author {
+            __typename
+            ... on User {
+              id
+              login
+              name
+              avatarUrl(size: 200)
+              createdAt
+              updatedAt
+            }
+            ... on Organization {
+              id
+              login
+              name
+              avatarUrl(size: 200)
+              createdAt
+              updatedAt
+            }
+            ... on Bot {
+              id
+              login
+              avatarUrl(size: 200)
+            }
+          }
+          mergedBy {
+            __typename
+            ... on User {
+              id
+              login
+              name
+              avatarUrl(size: 200)
+              createdAt
+              updatedAt
+            }
+            ... on Organization {
+              id
+              login
+              name
+              avatarUrl(size: 200)
+              createdAt
+              updatedAt
+            }
+            ... on Bot {
+              id
+              login
+              avatarUrl(size: 200)
+            }
+          }
+          closingIssuesReferences(first: 20) {
+            nodes {
+              id
+              number
+              title
+              url
+              state
+              repository {
+                nameWithOwner
               }
             }
           }

--- a/tests/e2e/sync-controls.spec.ts
+++ b/tests/e2e/sync-controls.spec.ts
@@ -60,7 +60,7 @@ test.describe("SyncControls (Playwright)", () => {
       });
     });
 
-    await page.getByRole("button", { name: "백필 실행" }).click();
+    await page.getByRole("button", { name: "백필 실행", exact: true }).click();
 
     await expect(
       page.getByText("백필이 성공적으로 실행되었습니다."),
@@ -132,7 +132,7 @@ test.describe("SyncControls (Playwright)", () => {
       });
     });
 
-    await page.getByRole("button", { name: "백필 실행" }).click();
+    await page.getByRole("button", { name: "백필 실행", exact: true }).click();
 
     await expect(
       page.getByText(


### PR DESCRIPTION
- enhance PR link backfill with DB schema update
- expand the pull_request_issues schema plus related queries/tests to persist richer PR link data (requires applying the migration)
- run PR link backfill in daily chunks with optional end dates and improved logging throughout collectors and sync service
- expose PR link backfill controls via the admin API/ UI, including input validation and helpful status feedback

Close #134