### PR TITLE
Clamp filter manager height and add regression test

### DIFF
--- a/src/components/dashboard/activity-view.test.tsx
+++ b/src/components/dashboard/activity-view.test.tsx
@@ -18,6 +18,7 @@ import {
   buildActivityItemDetailFixture,
   buildActivityItemFixture,
   buildActivityListResultFixture,
+  buildActivitySavedFilterFixture,
 } from "@/components/test-harness/activity-fixtures";
 import { fetchActivityDetail } from "@/lib/activity/client";
 import type {
@@ -583,6 +584,41 @@ describe("ActivityView", () => {
       "aria-pressed",
       "false",
     );
+  });
+
+  it("keeps saved filters manager scrollable when many filters exist", async () => {
+    const filters = Array.from({ length: 12 }, (_, index) =>
+      buildActivitySavedFilterFixture({
+        id: `saved-filter-${index + 1}`,
+        name: `Saved filter ${index + 1}`,
+      }),
+    );
+
+    mockFetchJsonOnce({ filters, limit: 20 });
+    const props = createDefaultProps();
+    render(<ActivityView {...props} />);
+
+    const manageButton = await screen.findByRole("button", {
+      name: "필터 관리",
+    });
+
+    await act(async () => {
+      manageButton.click();
+    });
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog.className).toContain("max-h-[calc(100vh-3rem)]");
+    expect(dialog.className).toContain("overflow-hidden");
+
+    const scrollRegion = dialog.querySelector("div.flex-1.overflow-y-auto");
+    expect(scrollRegion).toBeTruthy();
+    expect(scrollRegion?.className).toContain("min-h-0");
+
+    const applyButtons = within(scrollRegion as HTMLElement).getAllByRole(
+      "button",
+      { name: "필터 적용" },
+    );
+    expect(applyButtons.length).toBeGreaterThan(5);
   });
 
   it("provides canonical tooltips for attention filters", async () => {

--- a/src/components/dashboard/activity-view.tsx
+++ b/src/components/dashboard/activity-view.tsx
@@ -1788,7 +1788,7 @@ const SavedFiltersManager = ({
       <div
         role="dialog"
         aria-modal="true"
-        className="relative flex w-full max-w-3xl flex-col gap-4 rounded-xl border border-border bg-background p-6 shadow-2xl"
+        className="relative flex w-full max-w-3xl flex-col gap-4 rounded-xl border border-border bg-background p-6 shadow-2xl max-h-[calc(100vh-3rem)] overflow-hidden"
       >
         <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <h3 className="text-lg font-semibold text-foreground">필터 관리</h3>
@@ -1813,7 +1813,7 @@ const SavedFiltersManager = ({
           </p>
         ) : null}
 
-        <div className="flex-1 overflow-y-auto">
+        <div className="flex-1 overflow-y-auto min-h-0">
           {mode === "save" ? (
             <section className="mb-6 space-y-3 rounded-lg border border-border/60 bg-muted/10 p-4">
               <div className="flex flex-col gap-1">


### PR DESCRIPTION
- cap the saved-filter modal height and ensure inner list scrolls instead of overflowing the viewport
- cover the behavior with a regression test that opens the manager with many filters and asserts the layout classes