### PR TITLE
Handle GitHub discussion answers end-to-end

### DIFF
--- a/src/components/dashboard/activity/detail-shared.tsx
+++ b/src/components/dashboard/activity/detail-shared.tsx
@@ -868,12 +868,16 @@ export function ActivityCommentSection({
               comment.author?.id ??
               "알 수 없음";
 
+            const isAnswer = comment.isAnswer === true;
             const badges: string[] = [];
             if (comment.reviewId) {
               badges.push("리뷰 댓글");
             }
             if (comment.replyToId) {
               badges.push("답글");
+            }
+            if (isAnswer) {
+              badges.push("채택된 답변");
             }
 
             const renderedBody = resolveCommentBodyHtml(comment);
@@ -885,9 +889,16 @@ export function ActivityCommentSection({
                 ? (mentionControls.byCommentId[comment.id] ?? [])
                 : [];
 
+            const containerClasses = cn(
+              "rounded-md border px-4 py-3",
+              isAnswer
+                ? "border-pink-200 bg-pink-50/80"
+                : "border-border bg-background",
+            );
+
             return (
               <Fragment key={comment.id ?? `comment-${index}`}>
-                <article className="rounded-md border border-border bg-background px-4 py-3">
+                <article className={containerClasses}>
                   <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground/70">
                     <span className="font-semibold text-foreground">
                       {authorLabel}
@@ -1023,7 +1034,9 @@ export function ActivityCommentSection({
                         const badgeClass =
                           badge === "리뷰 댓글"
                             ? "bg-blue-100 text-blue-700 border border-blue-200"
-                            : "bg-amber-100 text-amber-700";
+                            : badge === "채택된 답변"
+                              ? "bg-pink-100 text-pink-700 border border-pink-200"
+                              : "bg-amber-100 text-amber-700";
                         return (
                           <span
                             key={`${comment.id}-${badge}`}

--- a/src/lib/activity/service.ts
+++ b/src/lib/activity/service.ts
@@ -2567,6 +2567,11 @@ export async function getActivityItemDetail(
         rawComment && typeof (rawComment as { url?: unknown }).url === "string"
           ? ((rawComment as { url: string }).url ?? null)
           : null;
+      const isAnswer =
+        rawComment &&
+        typeof (rawComment as { isAnswer?: unknown }).isAnswer === "boolean"
+          ? !!(rawComment as { isAnswer?: boolean }).isAnswer
+          : false;
 
       return {
         id: commentRow.id,
@@ -2581,6 +2586,7 @@ export async function getActivityItemDetail(
             ? commentRow.review_id
             : null,
         replyToId,
+        isAnswer,
         reactions: reactionMap.get(commentRow.id) ?? [],
       } satisfies ActivityItemComment;
     },

--- a/src/lib/activity/types.ts
+++ b/src/lib/activity/types.ts
@@ -177,6 +177,7 @@ export type ActivityItemComment = {
   url: string | null;
   reviewId: string | null;
   replyToId: string | null;
+  isAnswer?: boolean | null;
   reactions: ActivityReactionGroup[];
 };
 

--- a/src/lib/dashboard/attention.ts
+++ b/src/lib/dashboard/attention.ts
@@ -1787,6 +1787,17 @@ export async function fetchUnansweredMentionCandidates(
           AND reac.user_id = mc.mentioned_user_id
           AND COALESCE(reac.github_created_at, NOW()) >= mc.mentioned_at
        )
+       AND NOT (
+         mc.issue_id IS NOT NULL
+         AND (
+           LOWER(COALESCE(iss.data->>'__typename', '')) = 'discussion'
+           OR POSITION('/discussions/' IN COALESCE(iss.data->>'url', '')) > 0
+         )
+         AND iss.data->>'answerChosenAt' IS NOT NULL
+         AND iss.data->'answerChosenBy'->>'id' IS NOT NULL
+         AND iss.data->'answerChosenBy'->>'id' = mc.mentioned_user_id
+         AND NULLIF(iss.data->>'answerChosenAt', '')::timestamptz >= mc.mentioned_at
+       )
      ORDER BY mc.comment_id, mc.mentioned_user_id, mc.mentioned_at`,
     [excludedRepositoryIds, excludedUserIds],
   );

--- a/src/lib/github/collectors.test.ts
+++ b/src/lib/github/collectors.test.ts
@@ -646,6 +646,158 @@ describe("runCollection", () => {
     );
   });
 
+  it("stores discussion answers even when they are only returned via the answer field", async () => {
+    const discussionNode = {
+      __typename: "Discussion" as const,
+      id: "discussion-1",
+      number: 42,
+      title: "How do I repro?",
+      url: "https://github.com/acme/repo/discussions/42",
+      body: "What is the repro?",
+      bodyText: "What is the repro?",
+      bodyHTML: "<p>What is the repro?</p>",
+      createdAt: "2024-04-02T09:30:00.000Z",
+      updatedAt: "2024-04-02T10:00:00.000Z",
+      closedAt: null,
+      answerChosenAt: null,
+      locked: false,
+      author: {
+        id: "asker-1",
+        login: "asker",
+        name: "Asker",
+        avatarUrl: null,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+        __typename: "User",
+      },
+      answerChosenBy: null,
+      category: null,
+      comments: { totalCount: 1 },
+      reactions: null,
+    } satisfies Record<string, unknown>;
+
+    const answerComment = {
+      id: "discussion-answer-comment-1",
+      author: {
+        id: "helper-1",
+        login: "helper",
+        name: "Helper",
+        avatarUrl: null,
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+        __typename: "User",
+      },
+      createdAt: "2024-04-02T09:45:00.000Z",
+      updatedAt: null,
+      replyTo: null,
+      reactions: null,
+      url: "https://github.com/acme/repo/discussions/42#answer-1",
+      body: "Thanks!",
+      bodyText: "Thanks!",
+      bodyHTML: "<p>Thanks!</p>",
+    };
+
+    const requestMock = vi.fn(async (document: unknown) => {
+      if (document === organizationRepositoriesQuery) {
+        return {
+          organization: {
+            repositories: {
+              nodes: [
+                {
+                  id: "repo-1",
+                  name: "repo",
+                  nameWithOwner: "acme/repo",
+                  url: "https://github.com/acme/repo",
+                  isPrivate: false,
+                  createdAt: "2024-01-01T00:00:00.000Z",
+                  updatedAt: "2024-04-02T12:00:00.000Z",
+                  owner: {
+                    id: "owner-1",
+                    login: "owner",
+                    name: "Owner",
+                    avatarUrl: null,
+                    createdAt: "2024-01-01T00:00:00.000Z",
+                    updatedAt: "2024-01-01T00:00:00.000Z",
+                    __typename: "User",
+                  },
+                },
+              ],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        };
+      }
+
+      if (document === repositoryIssuesQuery) {
+        return { repository: { issues: emptyConnection } };
+      }
+
+      if (document === repositoryDiscussionsQuery) {
+        return {
+          repository: {
+            discussions: {
+              nodes: [discussionNode],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        };
+      }
+
+      if (document === discussionCommentsQuery) {
+        return {
+          repository: {
+            discussion: {
+              answer: answerComment,
+              comments: {
+                nodes: [],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          },
+        };
+      }
+
+      if (document === repositoryPullRequestsQuery) {
+        return { repository: { pullRequests: emptyConnection } };
+      }
+
+      if (document === pullRequestCommentsQuery) {
+        return { repository: { pullRequest: { comments: emptyConnection } } };
+      }
+
+      if (document === pullRequestReviewsQuery) {
+        return { repository: { pullRequest: { reviews: emptyConnection } } };
+      }
+
+      if (document === pullRequestReviewCommentsQuery) {
+        return {
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                nodes: [],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          },
+        };
+      }
+
+      throw new Error("Unexpected query");
+    });
+
+    await runCollection({
+      org: "acme",
+      client: { request: requestMock } as unknown as GraphQLClient,
+    });
+
+    expect(upsertCommentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "discussion-answer-comment-1",
+        issueId: "discussion-1",
+      }),
+    );
+  });
+
   it("stores closed discussions with closed state and timestamp", async () => {
     const discussionNode = {
       __typename: "Discussion" as const,

--- a/src/lib/github/queries.ts
+++ b/src/lib/github/queries.ts
@@ -911,6 +911,63 @@ export const discussionCommentsQuery = gql`
   query DiscussionComments($owner: String!, $name: String!, $number: Int!, $cursor: String) {
     repository(owner: $owner, name: $name) {
       discussion(number: $number) {
+        answer {
+          __typename
+          id
+          isAnswer
+          author {
+            __typename
+            ... on User {
+              id
+              login
+              name
+              avatarUrl(size: 200)
+              createdAt
+              updatedAt
+            }
+            ... on Organization {
+              id
+              login
+              name
+              avatarUrl(size: 200)
+              createdAt
+              updatedAt
+            }
+            ... on Bot {
+              id
+              login
+              avatarUrl(size: 200)
+            }
+            ... on Mannequin {
+              id
+              login
+              avatarUrl(size: 200)
+            }
+          }
+          createdAt
+          updatedAt
+          url
+          body
+          bodyText
+          bodyHTML
+          replyTo {
+            id
+          }
+          reactions(first: 25, orderBy: { field: CREATED_AT, direction: ASC }) {
+            nodes {
+              __typename
+              id
+              content
+              createdAt
+              user {
+                id
+                login
+                name
+                avatarUrl(size: 200)
+              }
+            }
+          }
+        }
         comments(first: 50, after: $cursor) {
           pageInfo {
             hasNextPage
@@ -919,6 +976,7 @@ export const discussionCommentsQuery = gql`
           nodes {
             __typename
             id
+            isAnswer
             author {
               __typename
               ... on User {


### PR DESCRIPTION
- extend discussionComments GraphQL query to fetch isAnswer on both the chosen answer node and regular comment nodes so we can detect accepted answers
- ensure the discussion comment collector merges the answer node with isAnswer: true, deduplicates via processedCommentIds, and continues storing reactions as before
- propagate the new flag through ActivityItemComment, highlight accepted answers inside the Overlay comment section, and add a “채택된 답변” badge/background so the UI surfaces the Answered post
- treat chosen answers as valid responses for unanswered-mention filtering: update the SQL to detect discussions whose answerChosenBy matches the mentioned user after the mention timestamp, and cover it with a DB-backed regression test