### PR TITLE
Fix stale-data warnings and ensure refresh controls active after sync

### DIFF
--- a/src/components/dashboard/analytics-view.tsx
+++ b/src/components/dashboard/analytics-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
-import type { Dispatch, SetStateAction } from "react";
+import { type Dispatch, type SetStateAction, useMemo } from "react";
 import {
   CartesianGrid,
   Legend,
@@ -34,7 +34,10 @@ import {
   individualMetricTooltips,
   organizationMetricTooltips,
 } from "@/components/dashboard/metric-tooltips";
-import { PageGenerationNotice } from "@/components/dashboard/page-generation-notice";
+import {
+  isPageDataStale,
+  PageGenerationNotice,
+} from "@/components/dashboard/page-generation-notice";
 import { RepoDistributionList } from "@/components/dashboard/repo-distribution-list";
 import {
   type FilterState,
@@ -214,6 +217,10 @@ export function AnalyticsView({
     activeMainBranchContributionEntries,
     individual,
   } = useAnalyticsViewModel(analytics);
+  const dataIsStale = useMemo(
+    () => isPageDataStale(analytics.generatedAt, analytics.lastSyncCompletedAt),
+    [analytics.generatedAt, analytics.lastSyncCompletedAt],
+  );
 
   return (
     <section className="flex flex-col gap-8">
@@ -234,6 +241,7 @@ export function AnalyticsView({
         generatedAt={analytics.generatedAt}
         latestSyncCompletedAt={analytics.lastSyncCompletedAt}
         dateTimeFormat={analytics.dateTimeFormat}
+        allowApplyWithoutChanges={dataIsStale}
       />
 
       <OrganizationMetricsSection
@@ -293,6 +301,7 @@ type AnalyticsHeaderSectionProps = {
   generatedAt?: string | null;
   latestSyncCompletedAt?: string | null;
   dateTimeFormat?: DashboardAnalytics["dateTimeFormat"];
+  allowApplyWithoutChanges?: boolean;
 };
 
 function AnalyticsHeaderSection({
@@ -312,6 +321,7 @@ function AnalyticsHeaderSection({
   generatedAt,
   latestSyncCompletedAt,
   dateTimeFormat,
+  allowApplyWithoutChanges = false,
 }: AnalyticsHeaderSectionProps) {
   return (
     <header className="flex flex-col gap-3">
@@ -335,6 +345,7 @@ function AnalyticsHeaderSection({
           void applyFilters();
         }}
         hasPendingChanges={hasPendingChanges}
+        allowApplyWithoutChanges={allowApplyWithoutChanges}
         isLoading={isLoading}
         error={error}
         repositories={repositories}

--- a/src/components/dashboard/dashboard-filter-panel.tsx
+++ b/src/components/dashboard/dashboard-filter-panel.tsx
@@ -21,6 +21,7 @@ type DashboardFilterPanelProps = {
   setFilters: React.Dispatch<React.SetStateAction<FilterState>>;
   onApply: () => void;
   hasPendingChanges: boolean;
+  allowApplyWithoutChanges?: boolean;
   isLoading: boolean;
   error: string | null;
   repositories: RepositoryProfile[];
@@ -37,6 +38,7 @@ export function DashboardFilterPanel({
   setFilters,
   onApply,
   hasPendingChanges,
+  allowApplyWithoutChanges = false,
   isLoading,
   error,
   repositories,
@@ -399,7 +401,9 @@ export function DashboardFilterPanel({
             <Button
               type="button"
               onClick={onApply}
-              disabled={isLoading || !hasPendingChanges}
+              disabled={
+                isLoading || (!hasPendingChanges && !allowApplyWithoutChanges)
+              }
               className="w-full sm:w-auto"
             >
               {isLoading ? "갱신 중..." : "필터 적용"}

--- a/src/components/dashboard/page-generation-notice.tsx
+++ b/src/components/dashboard/page-generation-notice.tsx
@@ -5,6 +5,23 @@ import type { DateTimeDisplayFormat } from "@/lib/date-time-format";
 import { formatDateTimeDisplay } from "@/lib/date-time-format";
 import { cn } from "@/lib/utils";
 
+export function isPageDataStale(
+  generatedAt?: string | null,
+  latestSyncCompletedAt?: string | null,
+) {
+  if (!generatedAt || !latestSyncCompletedAt) {
+    return false;
+  }
+  const generatedMs = Date.parse(generatedAt);
+  const latestMs = Date.parse(latestSyncCompletedAt);
+  if (!Number.isFinite(generatedMs) || !Number.isFinite(latestMs)) {
+    return false;
+  }
+  return generatedMs < latestMs;
+}
+
+const DEFAULT_STALE_MESSAGE = "보이는 결과는 최신 데이터가 아닐 수 있습니다.";
+
 type PageGenerationNoticeProps = {
   generatedAt?: string | null;
   latestSyncCompletedAt?: string | null;
@@ -35,14 +52,7 @@ export function PageGenerationNotice({
         format: dateTimeFormat ?? undefined,
       })
     : null;
-  const generatedMs = generatedAt ? Date.parse(generatedAt) : Number.NaN;
-  const latestSyncMs = latestSyncCompletedAt
-    ? Date.parse(latestSyncCompletedAt)
-    : Number.NaN;
-  const isStale =
-    Number.isFinite(generatedMs) &&
-    Number.isFinite(latestSyncMs) &&
-    generatedMs < latestSyncMs;
+  const isStale = isPageDataStale(generatedAt, latestSyncCompletedAt);
 
   const resolvedMessage = (() => {
     if (!isStale) {
@@ -54,10 +64,7 @@ export function PageGenerationNotice({
     if (typeof staleMessage === "string") {
       return staleMessage;
     }
-    if (formattedLatestSync) {
-      return `Latest GitHub Sync ${formattedLatestSync} 이후에 새 데이터가 있어요. 필터를 적용해 최신 상태를 확인해 주세요.`;
-    }
-    return "Latest GitHub Sync 이후에 새 데이터가 있어요. 필터를 적용해 최신 상태를 확인해 주세요.";
+    return DEFAULT_STALE_MESSAGE;
   })();
 
   return (

--- a/src/components/dashboard/people-view.tsx
+++ b/src/components/dashboard/people-view.tsx
@@ -10,7 +10,10 @@ import {
 } from "@/components/dashboard/metric-card.config";
 import { toCardHistory } from "@/components/dashboard/metric-history";
 import { individualMetricTooltips } from "@/components/dashboard/metric-tooltips";
-import { PageGenerationNotice } from "@/components/dashboard/page-generation-notice";
+import {
+  isPageDataStale,
+  PageGenerationNotice,
+} from "@/components/dashboard/page-generation-notice";
 import { RepoActivityTable } from "@/components/dashboard/repo-activity-table";
 import { useDashboardAnalytics } from "@/components/dashboard/use-dashboard-analytics";
 import { Button } from "@/components/ui/button";
@@ -231,6 +234,10 @@ export function PeopleView({
       void applyFilters(nextFilters);
     }
   }, [filters, filters.personId, initialContributorId, applyFilters]);
+  const dataIsStale = useMemo(
+    () => isPageDataStale(analytics.generatedAt, analytics.lastSyncCompletedAt),
+    [analytics.generatedAt, analytics.lastSyncCompletedAt],
+  );
 
   return (
     <section className="flex flex-col gap-8">
@@ -255,6 +262,7 @@ export function PeopleView({
             void applyFilters();
           }}
           hasPendingChanges={hasPendingChanges}
+          allowApplyWithoutChanges={dataIsStale}
           isLoading={isLoading}
           error={error}
           repositories={repositories}


### PR DESCRIPTION
- consolidate Page Generated warnings across Activity/Analytics/People and show “Displayed results may not be up to date” whenever cached data predates the latest sync
- allow “필터 적용” buttons to stay enabled in stale state by updating DashboardFilterPanel and Activity filter logic, and guard SSE client for test env
- swap style jsx block for a plain style tag so Vitest/jsdom render cleanly and keep EventSource checks from breaking tests