### PR TITLE
Recover dashboard client fetches after transient auth races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Prevented recoverable hydration mismatches in dashboard timestamp badges by
   normalizing locale-specific spacing differences and suppressing expected
   client-only text variance for auto-formatted timestamps.
+- Recovered transient post-login dashboard fetch failures by refreshing and
+  retrying the first unauthorized client-side requests for Analytics, People,
+  Activity saved filters, and the shared sync status panel.
 
 ## [0.3.1] - 2026-02-18
 

--- a/src/components/dashboard/activity-view.test.tsx
+++ b/src/components/dashboard/activity-view.test.tsx
@@ -14,6 +14,7 @@ import {
   PROJECT_FIELD_BADGE_CLASS,
 } from "@/components/dashboard/activity/detail-shared";
 import { ActivityView } from "@/components/dashboard/activity-view";
+import { __resetPostLoginAuthRecoveryForTests } from "@/components/dashboard/post-login-auth-recovery";
 import {
   buildActivityFilterOptionsFixture,
   buildActivityItemDetailFixture,
@@ -108,6 +109,7 @@ describe("ActivityView", () => {
   beforeEach(() => {
     resetActivityHelperCounters();
     resetMockFetch();
+    __resetPostLoginAuthRecoveryForTests();
     setDefaultFetchHandler((request) => {
       if (request.url.includes("/api/activity/filters")) {
         return createJsonResponse({ filters: [], limit: 5 });
@@ -123,6 +125,7 @@ describe("ActivityView", () => {
       );
     });
     mockRouter.replace.mockReset();
+    mockRouter.refresh.mockReset();
     fetchActivityDetailMock.mockReset();
     fetchActivityDetailMock.mockResolvedValue(buildActivityItemDetailFixture());
   });
@@ -134,6 +137,65 @@ describe("ActivityView", () => {
 
     expect(screen.getByText("첫번째 이슈")).toBeVisible();
     expect(screen.getByText(/페이지 1 \/ 1 \(총 1건\)/)).toBeVisible();
+  });
+
+  it("retries saved-filter bootstrap once after a transient unauthorized response", async () => {
+    vi.useFakeTimers();
+    try {
+      const savedFiltersHandler = vi
+        .fn()
+        .mockResolvedValueOnce(
+          createJsonResponse(
+            { success: false, message: "Authentication required." },
+            { status: 401 },
+          ),
+        )
+        .mockResolvedValueOnce(
+          createJsonResponse({
+            filters: [
+              buildActivitySavedFilterFixture({
+                id: "saved-1",
+                name: "재현 필터",
+              }),
+            ],
+            limit: 5,
+          }),
+        );
+
+      setDefaultFetchHandler((request) => {
+        if (request.url.includes("/api/activity/filters")) {
+          return savedFiltersHandler();
+        }
+        if (request.url.includes("/api/sync/status")) {
+          return createJsonResponse({
+            success: true,
+            status: { runs: [], logs: [], config: null },
+          });
+        }
+        throw new Error(
+          `No fetch mock registered for ${request.method ?? "GET"} ${request.url}`,
+        );
+      });
+
+      render(<ActivityView {...createDefaultProps()} />);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(100);
+      });
+      vi.useRealTimers();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("option", { name: "재현 필터" }),
+        ).toBeInTheDocument();
+      });
+
+      expect(mockRouter.refresh).toHaveBeenCalledTimes(1);
+      expect(savedFiltersHandler).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+      __resetPostLoginAuthRecoveryForTests();
+    }
   });
 
   it("applies quick filter and fetches updated results", async () => {

--- a/src/components/dashboard/activity-view.tsx
+++ b/src/components/dashboard/activity-view.tsx
@@ -29,6 +29,10 @@ import {
   isPageDataStale,
   PageGenerationNotice,
 } from "@/components/dashboard/page-generation-notice";
+import {
+  isUnauthorizedResponse,
+  retryOnceAfterUnauthorized,
+} from "@/components/dashboard/post-login-auth-recovery";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -2007,6 +2011,17 @@ export function ActivityView({
 }: ActivityViewProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const retryAfterUnauthorized = useCallback(
+    (execute: () => Promise<Response>) =>
+      retryOnceAfterUnauthorized({
+        execute,
+        refresh: () => {
+          router.refresh();
+        },
+        shouldRetry: isUnauthorizedResponse,
+      }),
+    [router],
+  );
   const perPageDefault =
     initialData.pageInfo.perPage ?? PER_PAGE_CHOICES[1] ?? 25;
   const labelMetadata = useMemo(() => {
@@ -2324,7 +2339,11 @@ export function ActivityView({
     let canceled = false;
     const loadInitialSyncStatus = async () => {
       try {
-        const response = await fetch("/api/sync/status");
+        const response = await retryAfterUnauthorized(() =>
+          fetch("/api/sync/status", {
+            cache: "no-store",
+          }),
+        );
         if (!response.ok) {
           return;
         }
@@ -2362,7 +2381,7 @@ export function ActivityView({
     return () => {
       canceled = true;
     };
-  }, []);
+  }, [retryAfterUnauthorized]);
 
   useEffect(() => {
     setDraft(initialState);
@@ -3126,7 +3145,11 @@ export function ActivityView({
     setSavedFiltersLoading(true);
     setSavedFiltersError(null);
     try {
-      const response = await fetch("/api/activity/filters");
+      const response = await retryAfterUnauthorized(() =>
+        fetch("/api/activity/filters", {
+          cache: "no-store",
+        }),
+      );
       let payload: {
         filters?: ActivitySavedFilter[];
         limit?: number;
@@ -3173,7 +3196,7 @@ export function ActivityView({
     } finally {
       setSavedFiltersLoading(false);
     }
-  }, [initialSavedFiltersLimit]);
+  }, [initialSavedFiltersLimit, retryAfterUnauthorized]);
 
   useEffect(() => {
     void loadSavedFilters();

--- a/src/components/dashboard/attention-view.tsx
+++ b/src/components/dashboard/attention-view.tsx
@@ -21,7 +21,10 @@ import {
   useState,
   useTransition,
 } from "react";
-
+import {
+  isUnauthorizedResponse,
+  retryOnceAfterUnauthorized,
+} from "@/components/dashboard/post-login-auth-recovery";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -3754,6 +3757,17 @@ export function AttentionView({
     insights.dateTimeFormat,
   );
   const router = useRouter();
+  const retryAfterUnauthorized = useCallback(
+    (execute: () => Promise<Response>) =>
+      retryOnceAfterUnauthorized({
+        execute,
+        refresh: () => {
+          router.refresh();
+        },
+        shouldRetry: isUnauthorizedResponse,
+      }),
+    [router],
+  );
   const [isRefreshing, startTransition] = useTransition();
   const [pendingMentionOverrideKey, setPendingMentionOverrideKey] = useState<
     string | null
@@ -3825,7 +3839,11 @@ export function AttentionView({
     let canceled = false;
     const loadInitialSyncState = async () => {
       try {
-        const response = await fetch("/api/sync/status");
+        const response = await retryAfterUnauthorized(() =>
+          fetch("/api/sync/status", {
+            cache: "no-store",
+          }),
+        );
         if (!response.ok) {
           return;
         }
@@ -3863,7 +3881,7 @@ export function AttentionView({
     return () => {
       canceled = true;
     };
-  }, []);
+  }, [retryAfterUnauthorized]);
 
   const handleMentionOverrideSuccess = useCallback(
     (params: {

--- a/src/components/dashboard/post-login-auth-recovery.test.ts
+++ b/src/components/dashboard/post-login-auth-recovery.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  __resetPostLoginAuthRecoveryForTests,
+  isUnauthorizedResponse,
+  retryOnceAfterUnauthorized,
+} from "@/components/dashboard/post-login-auth-recovery";
+
+describe("post-login auth recovery", () => {
+  beforeEach(() => {
+    __resetPostLoginAuthRecoveryForTests();
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    await vi.runOnlyPendingTimersAsync();
+    vi.useRealTimers();
+    __resetPostLoginAuthRecoveryForTests();
+  });
+
+  it("refreshes and retries once after the first unauthorized response", async () => {
+    const refresh = vi.fn();
+    const execute = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const pending = retryOnceAfterUnauthorized({
+      execute,
+      refresh,
+      shouldRetry: isUnauthorizedResponse,
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    const response = await pending;
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(response.status).toBe(200);
+  });
+
+  it("coalesces concurrent refreshes while multiple requests recover", async () => {
+    const refresh = vi.fn();
+    const firstExecute = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    const secondExecute = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const firstPending = retryOnceAfterUnauthorized({
+      execute: firstExecute,
+      refresh,
+      shouldRetry: isUnauthorizedResponse,
+    });
+    const secondPending = retryOnceAfterUnauthorized({
+      execute: secondExecute,
+      refresh,
+      shouldRetry: isUnauthorizedResponse,
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    await Promise.all([firstPending, secondPending]);
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(firstExecute).toHaveBeenCalledTimes(2);
+    expect(secondExecute).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/dashboard/post-login-auth-recovery.ts
+++ b/src/components/dashboard/post-login-auth-recovery.ts
@@ -1,0 +1,53 @@
+"use client";
+
+const POST_LOGIN_REFRESH_WAIT_MS = 100;
+
+let pendingRefreshBarrier: Promise<void> | null = null;
+
+function sleep(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function refreshAndWait(
+  refresh: () => void,
+  waitMs: number,
+): Promise<void> {
+  if (!pendingRefreshBarrier) {
+    refresh();
+    pendingRefreshBarrier = sleep(waitMs).finally(() => {
+      pendingRefreshBarrier = null;
+    });
+  }
+
+  await pendingRefreshBarrier;
+}
+
+export function isUnauthorizedResponse(response: Response) {
+  return response.status === 401;
+}
+
+export async function retryOnceAfterUnauthorized<T>({
+  execute,
+  refresh,
+  shouldRetry,
+  waitMs = POST_LOGIN_REFRESH_WAIT_MS,
+}: {
+  execute: () => Promise<T>;
+  refresh: () => void;
+  shouldRetry: (result: T) => boolean;
+  waitMs?: number;
+}): Promise<T> {
+  const firstResult = await execute();
+  if (!shouldRetry(firstResult)) {
+    return firstResult;
+  }
+
+  await refreshAndWait(refresh, waitMs);
+  return execute();
+}
+
+export function __resetPostLoginAuthRecoveryForTests() {
+  pendingRefreshBarrier = null;
+}

--- a/src/components/dashboard/sync-controls.test.tsx
+++ b/src/components/dashboard/sync-controls.test.tsx
@@ -8,6 +8,7 @@ import {
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { __resetPostLoginAuthRecoveryForTests } from "@/components/dashboard/post-login-auth-recovery";
 import {
   __syncControlsTestHelpers,
   SyncControls,
@@ -25,6 +26,9 @@ import {
 } from "../../../tests/setup/mock-fetch";
 
 const routerRefreshMock = vi.fn();
+const mockRouter = {
+  refresh: routerRefreshMock,
+};
 const mockActivityCacheSummary: ActivityCacheRefreshResult = {
   filterOptions: {
     cacheKey: "activity-filter-options",
@@ -98,9 +102,7 @@ function setBackfillRange(start: string, end: string) {
 }
 
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({
-    refresh: routerRefreshMock,
-  }),
+  useRouter: () => mockRouter,
   usePathname: () => "/dashboard/sync",
 }));
 
@@ -244,6 +246,7 @@ describe("sync controls helpers", () => {
 
 describe("SyncControls", () => {
   beforeEach(() => {
+    __resetPostLoginAuthRecoveryForTests();
     routerRefreshMock.mockReset();
     fetchMock.mockReset();
     setDefaultFetchHandler((request) => {

--- a/src/components/dashboard/sync-controls.tsx
+++ b/src/components/dashboard/sync-controls.tsx
@@ -2,6 +2,10 @@
 
 import { useRouter } from "next/navigation";
 import { useEffect, useId, useMemo, useState } from "react";
+import {
+  isUnauthorizedResponse,
+  retryOnceAfterUnauthorized,
+} from "@/components/dashboard/post-login-auth-recovery";
 import { ReauthModal } from "@/components/dashboard/reauth-modal";
 import { SyncSubTabs } from "@/components/dashboard/sync-subtabs";
 import { Button } from "@/components/ui/button";
@@ -536,9 +540,17 @@ export function SyncControls({
 
     const loadSummary = async () => {
       try {
-        const response = await fetch("/api/activity/cache/refresh", {
-          method: "GET",
-          signal: controller.signal,
+        const response = await retryOnceAfterUnauthorized({
+          execute: () =>
+            fetch("/api/activity/cache/refresh", {
+              method: "GET",
+              signal: controller.signal,
+              cache: "no-store",
+            }),
+          refresh: () => {
+            router.refresh();
+          },
+          shouldRetry: isUnauthorizedResponse,
         });
         if (!response.ok) {
           return;
@@ -559,13 +571,18 @@ export function SyncControls({
         }
 
         try {
-          const snapshotResponse = await fetch(
-            "/api/activity/snapshot/refresh",
-            {
-              method: "GET",
-              signal: controller.signal,
+          const snapshotResponse = await retryOnceAfterUnauthorized({
+            execute: () =>
+              fetch("/api/activity/snapshot/refresh", {
+                method: "GET",
+                signal: controller.signal,
+                cache: "no-store",
+              }),
+            refresh: () => {
+              router.refresh();
             },
-          );
+            shouldRetry: isUnauthorizedResponse,
+          });
 
           if (snapshotResponse.ok) {
             const snapshotData =
@@ -610,7 +627,7 @@ export function SyncControls({
       cancelled = true;
       controller.abort();
     };
-  }, [canManageSync]);
+  }, [canManageSync, router]);
 
   useEffect(() => {
     if (!canManageSync) {
@@ -623,9 +640,17 @@ export function SyncControls({
 
     const loadAutomationSummary = async () => {
       try {
-        const response = await fetch("/api/activity/status-automation", {
-          method: "GET",
-          signal: controller.signal,
+        const response = await retryOnceAfterUnauthorized({
+          execute: () =>
+            fetch("/api/activity/status-automation", {
+              method: "GET",
+              signal: controller.signal,
+              cache: "no-store",
+            }),
+          refresh: () => {
+            router.refresh();
+          },
+          shouldRetry: isUnauthorizedResponse,
         });
         if (!response.ok) {
           return;
@@ -665,7 +690,7 @@ export function SyncControls({
       cancelled = true;
       controller.abort();
     };
-  }, [canManageSync]);
+  }, [canManageSync, router]);
 
   const runGroups = useMemo(() => buildRunGroups(status), [status]);
   const primaryLatestRun = useMemo(

--- a/src/components/dashboard/sync-status-panel.test.tsx
+++ b/src/components/dashboard/sync-status-panel.test.tsx
@@ -1,14 +1,27 @@
 import { act, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { __resetPostLoginAuthRecoveryForTests } from "@/components/dashboard/post-login-auth-recovery";
 import { SyncStatusPanel } from "@/components/dashboard/sync-status-panel";
 import type { SyncConnectionState } from "@/lib/sync/client-stream";
 import type { SyncStreamEvent } from "@/lib/sync/events";
-import { setDefaultFetchHandler } from "../../../tests/setup/mock-fetch";
+import {
+  createJsonResponse,
+  fetchMock,
+  setDefaultFetchHandler,
+} from "../../../tests/setup/mock-fetch";
 
 const syncListeners = new Set<(event: SyncStreamEvent) => void>();
 const connectionListeners = new Set<(state: SyncConnectionState) => void>();
 let currentConnectionState: SyncConnectionState = "connecting";
+const routerRefreshMock = vi.fn();
+const mockRouter = {
+  refresh: routerRefreshMock,
+};
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => mockRouter,
+}));
 
 vi.mock("@/lib/sync/client-stream", () => ({
   subscribeToSyncStream: (listener: (event: SyncStreamEvent) => void) => {
@@ -47,6 +60,9 @@ describe("SyncStatusPanel", () => {
     syncListeners.clear();
     connectionListeners.clear();
     currentConnectionState = "connecting";
+    __resetPostLoginAuthRecoveryForTests();
+    fetchMock.mockReset();
+    routerRefreshMock.mockReset();
     setDefaultFetchHandler({
       json: {
         success: true,
@@ -117,5 +133,46 @@ describe("SyncStatusPanel", () => {
     });
 
     expect(screen.queryByText("Sync in progress")).not.toBeInTheDocument();
+  });
+
+  it("retries the initial status request once after a transient unauthorized response", async () => {
+    vi.useFakeTimers();
+    try {
+      setDefaultFetchHandler(
+        vi
+          .fn()
+          .mockResolvedValueOnce(
+            createJsonResponse(
+              { success: false, message: "Authentication required." },
+              { status: 401 },
+            ),
+          )
+          .mockResolvedValueOnce(
+            createJsonResponse({
+              success: true,
+              status: {
+                runs: [],
+                logs: [],
+              },
+            }),
+          ),
+      );
+
+      render(<SyncStatusPanel />);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(100);
+      });
+
+      expect(routerRefreshMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(
+        screen.queryByText(/Failed to fetch sync status \(401\)/),
+      ).not.toBeInTheDocument();
+    } finally {
+      await vi.runOnlyPendingTimersAsync();
+      vi.useRealTimers();
+      __resetPostLoginAuthRecoveryForTests();
+    }
   });
 });

--- a/src/components/dashboard/sync-status-panel.tsx
+++ b/src/components/dashboard/sync-status-panel.tsx
@@ -1,9 +1,14 @@
 "use client";
 
 import { AlertCircle, CheckCircle2, Loader2, RefreshCcw } from "lucide-react";
+import { useRouter } from "next/navigation";
 import type { JSX } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import {
+  isUnauthorizedResponse,
+  retryOnceAfterUnauthorized,
+} from "@/components/dashboard/post-login-auth-recovery";
 import {
   getCurrentSyncConnectionState,
   type SyncConnectionState,
@@ -275,6 +280,7 @@ function mergeResource(
 }
 
 export function SyncStatusPanel() {
+  const router = useRouter();
   const [connectionState, setConnectionState] = useState<SyncConnectionState>(
     () => getCurrentSyncConnectionState(),
   );
@@ -329,12 +335,19 @@ export function SyncStatusPanel() {
     setError(null);
 
     try {
-      const response = await fetch("/api/sync/status", {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
+      const response = await retryOnceAfterUnauthorized({
+        execute: () =>
+          fetch("/api/sync/status", {
+            method: "GET",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            cache: "no-store",
+          }),
+        refresh: () => {
+          router.refresh();
         },
-        cache: "no-store",
+        shouldRetry: isUnauthorizedResponse,
       });
 
       if (!response.ok) {
@@ -412,7 +425,7 @@ export function SyncStatusPanel() {
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [router]);
 
   const handleStreamEvent = useCallback(
     (event: SyncStreamEvent) => {

--- a/src/components/dashboard/use-dashboard-analytics.test.tsx
+++ b/src/components/dashboard/use-dashboard-analytics.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { __resetPostLoginAuthRecoveryForTests } from "@/components/dashboard/post-login-auth-recovery";
 import { useDashboardAnalytics } from "@/components/dashboard/use-dashboard-analytics";
 import {
   buildDashboardAnalyticsFixture,
@@ -12,6 +13,14 @@ import {
   mockFetchJsonOnce,
   mockFetchOnce,
 } from "../../../tests/setup/mock-fetch";
+
+const routerRefreshMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: routerRefreshMock,
+  }),
+}));
 
 function createDeferredResponse(body: unknown) {
   let resolveResponse: ((value: Response) => void) | null = null;
@@ -30,6 +39,8 @@ function createDeferredResponse(body: unknown) {
 describe("useDashboardAnalytics", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetPostLoginAuthRecoveryForTests();
+    routerRefreshMock.mockReset();
   });
 
   it("loads analytics successfully and normalizes filters", async () => {
@@ -112,6 +123,56 @@ describe("useDashboardAnalytics", () => {
     expect(result.current.isLoading).toBe(false);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(result.current.hasPendingChanges).toBe(true);
+  });
+
+  it("retries once after a transient unauthorized response", async () => {
+    vi.useFakeTimers();
+    try {
+      const initialAnalytics = buildDashboardAnalyticsFixture();
+      const defaultRange = {
+        start: initialAnalytics.range.start,
+        end: initialAnalytics.range.end,
+      };
+      const nextAnalytics = structuredClone(initialAnalytics);
+      nextAnalytics.range = {
+        ...nextAnalytics.range,
+        start: "2024-02-01T00:00:00.000Z",
+        end: "2024-02-07T23:59:59.999Z",
+      };
+
+      mockFetchJsonOnce(
+        { success: false, message: "Authentication required." },
+        { status: 401 },
+      );
+      mockFetchJsonOnce({ success: true, analytics: nextAnalytics });
+
+      const { result } = renderHook(() =>
+        useDashboardAnalytics({ initialAnalytics, defaultRange }),
+      );
+
+      let applyPromise: Promise<void> = Promise.resolve();
+      await act(async () => {
+        applyPromise = result.current.applyFilters({
+          ...result.current.filters,
+          start: nextAnalytics.range.start,
+          end: nextAnalytics.range.end,
+        });
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(100);
+        await applyPromise;
+      });
+
+      expect(routerRefreshMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(result.current.analytics).toEqual(nextAnalytics);
+      expect(result.current.error).toBeNull();
+    } finally {
+      await vi.runOnlyPendingTimersAsync();
+      vi.useRealTimers();
+      __resetPostLoginAuthRecoveryForTests();
+    }
   });
 
   it("keeps the latest filters when requests overlap and sanitizes missing data", async () => {

--- a/src/components/dashboard/use-dashboard-analytics.ts
+++ b/src/components/dashboard/use-dashboard-analytics.ts
@@ -1,6 +1,11 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  isUnauthorizedResponse,
+  retryOnceAfterUnauthorized,
+} from "@/components/dashboard/post-login-auth-recovery";
 import { PRESETS, type TimePresetKey } from "@/lib/dashboard/date-range";
 import type { DashboardAnalytics, WeekStart } from "@/lib/dashboard/types";
 
@@ -52,6 +57,7 @@ export function useDashboardAnalytics({
   initialAnalytics: DashboardAnalytics;
   defaultRange: { start: string; end: string };
 }): DashboardAnalyticsState {
+  const router = useRouter();
   const [analytics, setAnalytics] = useState(initialAnalytics);
   const [timeZone, setTimeZone] = useState(initialAnalytics.timeZone);
   const [weekStart, setWeekStart] = useState<WeekStart>(
@@ -76,140 +82,150 @@ export function useDashboardAnalytics({
     };
   }, []);
 
-  const load = useCallback(async (targetFilters: FilterState) => {
-    setIsLoading(true);
-    setError(null);
-    requestCounterRef.current += 1;
-    const requestId = requestCounterRef.current;
-    latestStartedRequestRef.current = requestId;
-    activeControllerRef.current?.abort();
-    const controller = new AbortController();
-    activeControllerRef.current = controller;
-    const isLatestRequest = (id: number) =>
-      latestStartedRequestRef.current === id;
+  const load = useCallback(
+    async (targetFilters: FilterState) => {
+      setIsLoading(true);
+      setError(null);
+      requestCounterRef.current += 1;
+      const requestId = requestCounterRef.current;
+      latestStartedRequestRef.current = requestId;
+      activeControllerRef.current?.abort();
+      const controller = new AbortController();
+      activeControllerRef.current = controller;
+      const isLatestRequest = (id: number) =>
+        latestStartedRequestRef.current === id;
 
-    try {
-      const params = new URLSearchParams({
-        start: targetFilters.start,
-        end: targetFilters.end,
-      });
-      if (targetFilters.repositoryIds.length) {
-        params.set("repos", targetFilters.repositoryIds.join(","));
-      }
-      if (targetFilters.personId) {
-        params.set("person", targetFilters.personId);
-      }
-
-      const response = await fetch(
-        `/api/dashboard/analytics?${params.toString()}`,
-        { signal: controller.signal },
-      );
-      const data = await response.json();
-      if (!data.success) {
-        throw new Error(
-          data.message ?? "대시보드 데이터를 불러오지 못했습니다.",
-        );
-      }
-
-      const nextAnalytics = data.analytics as DashboardAnalytics;
-      if (!isLatestRequest(requestId)) {
-        return;
-      }
-
-      setAnalytics(nextAnalytics);
-      if (nextAnalytics.timeZone) {
-        setTimeZone(nextAnalytics.timeZone);
-      }
-      if (nextAnalytics.weekStart) {
-        setWeekStart(nextAnalytics.weekStart);
-      }
-      const availableRepoIds = new Set(
-        nextAnalytics.repositories.map((repo) => repo.id),
-      );
-      const availableContributorIds = new Set(
-        nextAnalytics.contributors.map((contributor) => contributor.id),
-      );
-      const sanitizedRepoIds = targetFilters.repositoryIds.filter((id) =>
-        availableRepoIds.has(id),
-      );
-      const nextRepoIds =
-        sanitizedRepoIds.length === targetFilters.repositoryIds.length
-          ? [...targetFilters.repositoryIds]
-          : sanitizedRepoIds;
-      const nextPersonId =
-        targetFilters.personId &&
-        availableContributorIds.has(targetFilters.personId)
-          ? targetFilters.personId
-          : null;
-      const sanitizedTarget: FilterState = {
-        start: nextAnalytics.range.start,
-        end: nextAnalytics.range.end,
-        preset: targetFilters.preset,
-        repositoryIds: nextRepoIds,
-        personId: nextPersonId,
-      };
-
-      setFilters((current) => {
-        if (!isLatestRequest(requestId)) {
-          return current;
+      try {
+        const params = new URLSearchParams({
+          start: targetFilters.start,
+          end: targetFilters.end,
+        });
+        if (targetFilters.repositoryIds.length) {
+          params.set("repos", targetFilters.repositoryIds.join(","));
         }
-        // Keep any newer in-flight edits if the user changed filters while this request was running.
-        if (current !== targetFilters) {
-          const filteredRepoIds = current.repositoryIds.filter((id) =>
-            availableRepoIds.has(id),
-          );
-          const repoChanged =
-            filteredRepoIds.length !== current.repositoryIds.length;
-          const personFromCurrent =
-            current.personId && availableContributorIds.has(current.personId)
-              ? current.personId
-              : null;
+        if (targetFilters.personId) {
+          params.set("person", targetFilters.personId);
+        }
 
-          if (!repoChanged && personFromCurrent === current.personId) {
+        const response = await retryOnceAfterUnauthorized({
+          execute: () =>
+            fetch(`/api/dashboard/analytics?${params.toString()}`, {
+              signal: controller.signal,
+              cache: "no-store",
+            }),
+          refresh: () => {
+            router.refresh();
+          },
+          shouldRetry: isUnauthorizedResponse,
+        });
+        const data = await response.json();
+        if (!data.success) {
+          throw new Error(
+            data.message ?? "대시보드 데이터를 불러오지 못했습니다.",
+          );
+        }
+
+        const nextAnalytics = data.analytics as DashboardAnalytics;
+        if (!isLatestRequest(requestId)) {
+          return;
+        }
+
+        setAnalytics(nextAnalytics);
+        if (nextAnalytics.timeZone) {
+          setTimeZone(nextAnalytics.timeZone);
+        }
+        if (nextAnalytics.weekStart) {
+          setWeekStart(nextAnalytics.weekStart);
+        }
+        const availableRepoIds = new Set(
+          nextAnalytics.repositories.map((repo) => repo.id),
+        );
+        const availableContributorIds = new Set(
+          nextAnalytics.contributors.map((contributor) => contributor.id),
+        );
+        const sanitizedRepoIds = targetFilters.repositoryIds.filter((id) =>
+          availableRepoIds.has(id),
+        );
+        const nextRepoIds =
+          sanitizedRepoIds.length === targetFilters.repositoryIds.length
+            ? [...targetFilters.repositoryIds]
+            : sanitizedRepoIds;
+        const nextPersonId =
+          targetFilters.personId &&
+          availableContributorIds.has(targetFilters.personId)
+            ? targetFilters.personId
+            : null;
+        const sanitizedTarget: FilterState = {
+          start: nextAnalytics.range.start,
+          end: nextAnalytics.range.end,
+          preset: targetFilters.preset,
+          repositoryIds: nextRepoIds,
+          personId: nextPersonId,
+        };
+
+        setFilters((current) => {
+          if (!isLatestRequest(requestId)) {
             return current;
           }
+          // Keep any newer in-flight edits if the user changed filters while this request was running.
+          if (current !== targetFilters) {
+            const filteredRepoIds = current.repositoryIds.filter((id) =>
+              availableRepoIds.has(id),
+            );
+            const repoChanged =
+              filteredRepoIds.length !== current.repositoryIds.length;
+            const personFromCurrent =
+              current.personId && availableContributorIds.has(current.personId)
+                ? current.personId
+                : null;
 
-          return {
-            ...current,
-            repositoryIds: repoChanged
-              ? filteredRepoIds
-              : current.repositoryIds,
-            personId: personFromCurrent,
-          };
-        }
+            if (!repoChanged && personFromCurrent === current.personId) {
+              return current;
+            }
 
-        return sanitizedTarget;
-      });
-      setAppliedFilters((current) => {
+            return {
+              ...current,
+              repositoryIds: repoChanged
+                ? filteredRepoIds
+                : current.repositoryIds,
+              personId: personFromCurrent,
+            };
+          }
+
+          return sanitizedTarget;
+        });
+        setAppliedFilters((current) => {
+          if (!isLatestRequest(requestId)) {
+            return current;
+          }
+          return sanitizedTarget;
+        });
+      } catch (fetchError) {
         if (!isLatestRequest(requestId)) {
-          return current;
+          return;
         }
-        return sanitizedTarget;
-      });
-    } catch (fetchError) {
-      if (!isLatestRequest(requestId)) {
-        return;
+        if (
+          fetchError instanceof DOMException &&
+          fetchError.name === "AbortError"
+        ) {
+          return;
+        }
+        setError(
+          fetchError instanceof Error
+            ? fetchError.message
+            : "대시보드 데이터를 불러오지 못했습니다.",
+        );
+      } finally {
+        if (isLatestRequest(requestId)) {
+          setIsLoading(false);
+        }
+        if (activeControllerRef.current === controller) {
+          activeControllerRef.current = null;
+        }
       }
-      if (
-        fetchError instanceof DOMException &&
-        fetchError.name === "AbortError"
-      ) {
-        return;
-      }
-      setError(
-        fetchError instanceof Error
-          ? fetchError.message
-          : "대시보드 데이터를 불러오지 못했습니다.",
-      );
-    } finally {
-      if (isLatestRequest(requestId)) {
-        setIsLoading(false);
-      }
-      if (activeControllerRef.current === controller) {
-        activeControllerRef.current = null;
-      }
-    }
-  }, []);
+    },
+    [router],
+  );
 
   const applyFilters = useCallback(
     async (nextFilters?: FilterState) => {

--- a/tests/e2e/activity.spec.ts
+++ b/tests/e2e/activity.spec.ts
@@ -327,6 +327,64 @@ test.describe("ActivityView (Playwright)", () => {
     await expect(page.getByText("페이지 2 / 2 (총 2건)")).toBeVisible();
     await expect(page.getByRole("button", { name: "다음" })).toBeDisabled();
   });
+
+  test("recovers saved filters after a transient unauthorized bootstrap response", async ({
+    page,
+  }) => {
+    await page.goto("/test-harness/auth/session?userId=activity-user");
+
+    let savedFilterRequestCount = 0;
+    const savedFilters: ActivitySavedFilter[] = [
+      {
+        id: "saved-1",
+        name: "My focus",
+        payload: {},
+        createdAt: new Date("2024-04-01T00:00:00.000Z").toISOString(),
+        updatedAt: new Date("2024-04-01T00:00:00.000Z").toISOString(),
+      },
+    ];
+
+    await page.route("**/api/activity/filters**", async (route) => {
+      if (route.request().method() !== "GET") {
+        await route.fulfill({
+          status: 405,
+          contentType: "application/json",
+          body: JSON.stringify({ message: "Method not allowed" }),
+        });
+        return;
+      }
+
+      savedFilterRequestCount += 1;
+      if (savedFilterRequestCount === 1) {
+        await route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: false,
+            message: "Authentication required.",
+          }),
+        });
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ filters: savedFilters, limit: 5 }),
+      });
+    });
+
+    await page.goto(ACTIVITY_PATH);
+
+    await expect.poll(() => savedFilterRequestCount).toBe(2);
+    await expect(page.getByLabel("저장된 필터 선택")).toBeEnabled();
+    await expect(page.locator('option[value="saved-1"]')).toHaveText(
+      "My focus",
+    );
+    await expect(
+      page.getByText("저장된 필터를 불러오지 못했어요."),
+    ).toHaveCount(0);
+  });
 });
 
 test.describe("ActivityView badges & overlay presentation", () => {

--- a/tests/e2e/analytics.spec.ts
+++ b/tests/e2e/analytics.spec.ts
@@ -47,6 +47,53 @@ test.describe("AnalyticsView (Playwright)", () => {
     expect(url.searchParams.get("end")).toContain("2024-02-10");
   });
 
+  test("recovers from a transient unauthorized response when applying filters", async ({
+    page,
+  }) => {
+    let analyticsRequestCount = 0;
+
+    await page.route("**/api/dashboard/analytics**", async (route) => {
+      analyticsRequestCount += 1;
+
+      if (analyticsRequestCount === 1) {
+        await route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: false,
+            message: "Authentication required.",
+          }),
+        });
+        return;
+      }
+
+      const analytics = buildDashboardAnalyticsFixture();
+      const prsCreated = analytics.organization.metrics.prsCreated;
+      prsCreated.previous = 1200;
+      prsCreated.current = 98765;
+      prsCreated.absoluteChange = prsCreated.current - prsCreated.previous;
+      prsCreated.percentChange =
+        prsCreated.previous === 0
+          ? null
+          : prsCreated.absoluteChange / prsCreated.previous;
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, analytics }),
+      });
+    });
+
+    await page.goto(ANALYTICS_PATH);
+
+    await page.getByRole("button", { name: "최근 30일" }).click();
+    await page.getByRole("button", { name: "필터 적용" }).click();
+
+    await expect.poll(() => analyticsRequestCount).toBe(2);
+    await expect(page.getByText("98,765")).toBeVisible();
+    await expect(page.getByText("Authentication required.")).toHaveCount(0);
+  });
+
   test("switches average PR size mode and sorts repository metrics", async ({
     page,
   }) => {

--- a/tests/e2e/dashboard-auth-recovery.spec.ts
+++ b/tests/e2e/dashboard-auth-recovery.spec.ts
@@ -1,0 +1,90 @@
+import { buildSyncStatusFixture } from "@/components/test-harness/sync-fixtures";
+import { expect, test } from "./harness/test";
+
+test.describe("Dashboard auth recovery (Playwright)", () => {
+  test.setTimeout(120_000);
+
+  test("recovers the sync status panel after transient unauthorized responses", async ({
+    page,
+  }) => {
+    await page.goto("/test-harness/auth/session?userId=e2e-user");
+
+    let syncStatusRequestCount = 0;
+    const now = new Date().toISOString();
+    const syncStatus = buildSyncStatusFixture();
+    const activeRun = syncStatus.runs[0];
+    const runningLog = activeRun?.logs[0];
+
+    if (!activeRun || !runningLog) {
+      throw new Error("Expected sync status fixture to include a run and log");
+    }
+
+    syncStatus.runs = [
+      {
+        ...activeRun,
+        status: "running",
+        startedAt: now,
+        completedAt: null,
+        logs: [
+          {
+            ...runningLog,
+            status: "running",
+            message: "Processing issues",
+            startedAt: now,
+            finishedAt: null,
+          },
+        ],
+      },
+    ];
+    syncStatus.logs = [
+      {
+        id: 1,
+        resource: "issues",
+        status: "running",
+        message: "Processing issues",
+        started_at: now,
+        finished_at: null,
+        run_id: activeRun.id,
+      },
+    ];
+
+    await page.route("**/api/activity/filters**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ filters: [], limit: 5 }),
+      });
+    });
+
+    await page.route("**/api/sync/status**", async (route) => {
+      syncStatusRequestCount += 1;
+
+      if (syncStatusRequestCount <= 2) {
+        await route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: false,
+            message: "Authentication required.",
+          }),
+        });
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          status: syncStatus,
+        }),
+      });
+    });
+
+    await page.goto("/dashboard/activity");
+
+    await expect.poll(() => syncStatusRequestCount >= 3).toBe(true);
+    await expect(page.getByText("Sync in progress")).toBeVisible();
+    await expect(page.getByText("Authentication required.")).toHaveCount(0);
+  });
+});

--- a/tests/e2e/people.spec.ts
+++ b/tests/e2e/people.spec.ts
@@ -52,4 +52,47 @@ test.describe("PeopleView (Playwright)", () => {
     );
     await expect(applyButton).toBeDisabled();
   });
+
+  test("recovers from a transient unauthorized response during person auto-selection", async ({
+    page,
+  }) => {
+    const initialAnalytics = buildDashboardAnalyticsFixture();
+    const fallbackPersonId = initialAnalytics.contributors[0]?.id ?? "user-1";
+    let analyticsRequestCount = 0;
+
+    await page.route("**/api/dashboard/analytics**", async (route) => {
+      analyticsRequestCount += 1;
+      const requestUrl = new URL(route.request().url());
+      const personId =
+        requestUrl.searchParams.get("person") ?? fallbackPersonId;
+
+      if (analyticsRequestCount === 1) {
+        await route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: false,
+            message: "Authentication required.",
+          }),
+        });
+        return;
+      }
+
+      const analytics = buildDashboardAnalyticsForPerson(personId);
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, analytics }),
+      });
+    });
+
+    await page.goto(PEOPLE_PATH);
+
+    await expect.poll(() => analyticsRequestCount).toBe(2);
+    await expect(page.getByText("활동 요약 · octoaide")).toBeVisible();
+    await expect(page.getByRole("button", { name: "octoaide" })).toHaveClass(
+      /bg-primary/,
+    );
+    await expect(page.getByText("Authentication required.")).toHaveCount(0);
+  });
 });


### PR DESCRIPTION
## Summary
- add a shared client-side recovery path for transient post-login 401s on authenticated dashboard fetches
- apply the recovery flow to Analytics/People, the shared SyncStatusPanel, Activity saved filters, and the initial authenticated Sync controls/Attention fetches
- extend component and Playwright coverage for the unauthorized-once recovery path and document the fix in the changelog

## Testing
- pnpm run typecheck
- biome ci --error-on-warnings .
- pnpm lint:md
- pnpm run test:e2e -- tests/e2e/analytics.spec.ts tests/e2e/activity.spec.ts tests/e2e/dashboard-auth-recovery.spec.ts
- pnpm run test:e2e -- tests/e2e/people.spec.ts

Closes #356