### PR TITLE
Extract custom hooks from view components

### DIFF
--- a/src/components/dashboard/activity-view.tsx
+++ b/src/components/dashboard/activity-view.tsx
@@ -24,7 +24,8 @@ import {
   useRef,
   useState,
 } from "react";
-
+import { useActivityDetailState } from "@/components/dashboard/hooks/use-activity-detail";
+import { useSyncStream } from "@/components/dashboard/hooks/use-sync-stream";
 import {
   isPageDataStale,
   PageGenerationNotice,
@@ -42,7 +43,6 @@ import {
   ATTENTION_OPTIONS,
   ATTENTION_REQUIRED_VALUES,
 } from "@/lib/activity/attention-options";
-import { fetchActivityDetail } from "@/lib/activity/client";
 import type { ActivityFilterState as FilterState } from "@/lib/activity/filter-state";
 import {
   buildFilterState,
@@ -59,7 +59,6 @@ import type {
   ActivityIssueWeightFilter,
   ActivityItem,
   ActivityItemType as ActivityItemCategory,
-  ActivityItemDetail,
   ActivityLinkedIssueFilter,
   ActivityListParams,
   ActivityListResult,
@@ -70,7 +69,6 @@ import type {
   IssueProjectStatus,
 } from "@/lib/activity/types";
 import type { DateTimeDisplayFormat } from "@/lib/date-time-format";
-import { subscribeToSyncStream } from "@/lib/sync/client-stream";
 import { cn } from "@/lib/utils";
 import { ActivityDetailOverlay } from "./activity/activity-detail-overlay";
 import { ActivityListItemSummary } from "./activity/activity-list-item-summary";
@@ -2235,13 +2233,16 @@ export function ActivityView({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notification, setNotification] = useState<string | null>(null);
-  const [openItemId, setOpenItemId] = useState<string | null>(null);
-  const [detailMap, setDetailMap] = useState<
-    Record<string, ActivityItemDetail | null>
-  >({});
-  const [loadingDetailIds, setLoadingDetailIds] = useState<Set<string>>(
-    () => new Set<string>(),
-  );
+  const {
+    openItemId,
+    detailMap,
+    loadingDetailIds,
+    selectItem: handleSelectItem,
+    closeItem: handleCloseItem,
+    updateDetailItem,
+    loadDetail,
+    pruneStaleItems,
+  } = useActivityDetailState({ useMentionAi: applied.useMentionAi });
   const [updatingStatusIds, setUpdatingStatusIds] = useState<Set<string>>(
     () => new Set<string>(),
   );
@@ -2297,17 +2298,17 @@ export function ActivityView({
     setApplied((current) => normalizeFilterState(current));
   }, [normalizeFilterState]);
 
-  useEffect(() => {
-    const updateAutoSyncState = () => {
-      setAutomaticSyncActive(autoSyncRunIdsRef.current.size > 0);
-    };
-    const unsubscribe = subscribeToSyncStream((event) => {
+  useSyncStream(
+    useCallback((event) => {
       if (event.type === "run-completed" && event.status === "success") {
         setListData((current) => ({
           ...current,
           lastSyncCompletedAt: event.completedAt,
         }));
       }
+      const updateAutoSyncState = () => {
+        setAutomaticSyncActive(autoSyncRunIdsRef.current.size > 0);
+      };
       if (event.type === "run-started" && event.runType === "automatic") {
         if (!autoSyncRunIdsRef.current.has(event.runId)) {
           autoSyncRunIdsRef.current.add(event.runId);
@@ -2329,9 +2330,8 @@ export function ActivityView({
           updateAutoSyncState();
         }
       }
-    });
-    return unsubscribe;
-  }, []);
+    }, []),
+  );
 
   useEffect(() => {
     let canceled = false;
@@ -2422,7 +2422,6 @@ export function ActivityView({
     "자동 동기화 중이므로 완료 후 실행할 수 있어요.";
 
   const fetchControllerRef = useRef<AbortController | null>(null);
-  const detailControllersRef = useRef(new Map<string, AbortController>());
   const requestCounterRef = useRef(0);
   const notificationTimerRef = useRef<NodeJS.Timeout | null>(null);
   const appliedQuickParamRef = useRef<string | null>(null);
@@ -2431,10 +2430,6 @@ export function ActivityView({
   useEffect(() => {
     return () => {
       fetchControllerRef.current?.abort();
-      detailControllersRef.current.forEach((controller) => {
-        controller.abort();
-      });
-      detailControllersRef.current.clear();
       if (notificationTimerRef.current) {
         clearTimeout(notificationTimerRef.current);
       }
@@ -2454,53 +2449,8 @@ export function ActivityView({
 
   useEffect(() => {
     const validIds = new Set(listData.items.map((item) => item.id));
-
-    if (openItemId && !validIds.has(openItemId)) {
-      const controller = detailControllersRef.current.get(openItemId);
-      if (controller) {
-        controller.abort();
-        detailControllersRef.current.delete(openItemId);
-      }
-      setOpenItemId(null);
-    }
-
-    setDetailMap((current) => {
-      const entries = Object.entries(current);
-      if (!entries.length) {
-        return current;
-      }
-
-      let changed = false;
-      const next: Record<string, ActivityItemDetail | null> = {};
-      entries.forEach(([id, detail]) => {
-        if (validIds.has(id)) {
-          next[id] = detail;
-        } else {
-          changed = true;
-        }
-      });
-
-      return changed ? next : current;
-    });
-
-    setLoadingDetailIds((current) => {
-      if (!current.size) {
-        return current;
-      }
-
-      let changed = false;
-      const next = new Set<string>();
-      current.forEach((id) => {
-        if (validIds.has(id)) {
-          next.add(id);
-        } else {
-          changed = true;
-        }
-      });
-
-      return changed ? next : current;
-    });
-  }, [openItemId, listData.items]);
+    pruneStaleItems(validIds);
+  }, [listData.items, pruneStaleItems]);
 
   const repositoryOptions = useMemo<MultiSelectOption[]>(
     () =>
@@ -3360,31 +3310,20 @@ export function ActivityView({
           } satisfies ActivityMentionWait;
         };
 
-        setDetailMap((current) => {
-          const existing = current[itemId];
-          if (!existing || !existing.item) {
-            return current;
-          }
-          const nextItem: ActivityItem = {
-            ...existing.item,
+        updateDetailItem({
+          id: itemId,
+          updater: (prev) => ({
+            ...prev,
             attention: {
-              ...existing.item.attention,
+              ...prev.attention,
               unansweredMention: computeNextAttention(
-                existing.item.attention.unansweredMention,
+                prev.attention.unansweredMention,
               ),
             },
-            mentionWaits: existing.item.mentionWaits?.map((wait) =>
+            mentionWaits: prev.mentionWaits?.map((wait) =>
               updateMentionWait(wait),
             ),
-          };
-
-          return {
-            ...current,
-            [itemId]: {
-              ...existing,
-              item: nextItem,
-            },
-          };
+          }),
         });
 
         setListData((current) => ({
@@ -3427,7 +3366,7 @@ export function ActivityView({
         setPendingMentionOverrideKey(null);
       }
     },
-    [applied, fetchActivity, showNotification],
+    [applied, fetchActivity, showNotification, updateDetailItem],
   );
 
   const handleApplyQuickFilter = useCallback(
@@ -3953,59 +3892,6 @@ export function ActivityView({
     fetchActivity({ ...applied }, { jumpToDate: effectiveJump });
   }, [activeTimezone, applied, fetchActivity, jumpDate]);
 
-  const loadDetail = useCallback(
-    async (id: string) => {
-      if (!id) {
-        return;
-      }
-
-      setLoadingDetailIds((current) => {
-        if (current.has(id)) {
-          return current;
-        }
-        const next = new Set(current);
-        next.add(id);
-        return next;
-      });
-
-      const existing = detailControllersRef.current.get(id);
-      existing?.abort();
-
-      const controller = new AbortController();
-      detailControllersRef.current.set(id, controller);
-
-      try {
-        const detail = await fetchActivityDetail(id, {
-          signal: controller.signal,
-          useMentionAi: applied.useMentionAi,
-        });
-        setDetailMap((current) => ({
-          ...current,
-          [id]: detail,
-        }));
-      } catch (detailError) {
-        if ((detailError as Error).name === "AbortError") {
-          return;
-        }
-        console.error(detailError);
-        setDetailMap((current) => ({
-          ...current,
-          [id]: null,
-        }));
-      } finally {
-        detailControllersRef.current.delete(id);
-        setLoadingDetailIds((current) => {
-          if (!current.has(id)) {
-            return current;
-          }
-          const next = new Set(current);
-          next.delete(id);
-          return next;
-        });
-      }
-    },
-    [applied.useMentionAi],
-  );
   const handleResyncItem = useCallback(
     async (item: ActivityItem) => {
       const targetId = item.id;
@@ -4109,16 +3995,7 @@ export function ActivityView({
                 existing.id === conflictItem.id ? conflictItem : existing,
               ),
             }));
-            setDetailMap((current) => {
-              const existing = current[conflictItem.id];
-              if (!existing) {
-                return current;
-              }
-              return {
-                ...current,
-                [conflictItem.id]: { ...existing, item: conflictItem },
-              };
-            });
+            updateDetailItem(conflictItem);
           }
 
           let message = "상태를 변경하지 못했어요.";
@@ -4145,16 +4022,7 @@ export function ActivityView({
             existing.id === updatedItem.id ? updatedItem : existing,
           ),
         }));
-        setDetailMap((current) => {
-          const existing = current[updatedItem.id];
-          if (!existing) {
-            return current;
-          }
-          return {
-            ...current,
-            [updatedItem.id]: { ...existing, item: updatedItem },
-          };
-        });
+        updateDetailItem(updatedItem);
 
         const label =
           ISSUE_STATUS_LABEL_MAP.get(
@@ -4175,7 +4043,7 @@ export function ActivityView({
         });
       }
     },
-    [showNotification],
+    [showNotification, updateDetailItem],
   );
 
   const handleUpdateProjectField = useCallback(
@@ -4275,16 +4143,7 @@ export function ActivityView({
                 existing.id === conflictItem.id ? conflictItem : existing,
               ),
             }));
-            setDetailMap((current) => {
-              const existing = current[conflictItem.id];
-              if (!existing) {
-                return current;
-              }
-              return {
-                ...current,
-                [conflictItem.id]: { ...existing, item: conflictItem },
-              };
-            });
+            updateDetailItem(conflictItem);
           }
 
           let message = "값을 업데이트하지 못했어요.";
@@ -4311,16 +4170,7 @@ export function ActivityView({
             existing.id === updatedItem.id ? updatedItem : existing,
           ),
         }));
-        setDetailMap((current) => {
-          const existing = current[updatedItem.id];
-          if (!existing) {
-            return current;
-          }
-          return {
-            ...current,
-            [updatedItem.id]: { ...existing, item: updatedItem },
-          };
-        });
+        updateDetailItem(updatedItem);
 
         const label = PROJECT_FIELD_LABELS[field];
         showNotification(`${label} 값을 업데이트했어요.`);
@@ -4340,53 +4190,7 @@ export function ActivityView({
         });
       }
     },
-    [showNotification],
-  );
-
-  const handleSelectItem = useCallback(
-    (id: string) => {
-      setOpenItemId((current) => {
-        if (current === id) {
-          const controller = detailControllersRef.current.get(id);
-          if (controller) {
-            controller.abort();
-            detailControllersRef.current.delete(id);
-          }
-          setLoadingDetailIds((loadings) => {
-            if (!loadings.has(id)) {
-              return loadings;
-            }
-            const updated = new Set(loadings);
-            updated.delete(id);
-            return updated;
-          });
-          return null;
-        }
-
-        if (current) {
-          const controller = detailControllersRef.current.get(current);
-          if (controller) {
-            controller.abort();
-            detailControllersRef.current.delete(current);
-          }
-          setLoadingDetailIds((loadings) => {
-            if (!loadings.has(current)) {
-              return loadings;
-            }
-            const updated = new Set(loadings);
-            updated.delete(current);
-            return updated;
-          });
-        }
-
-        if (!detailMap[id] && !loadingDetailIds.has(id)) {
-          void loadDetail(id);
-        }
-
-        return id;
-      });
-    },
-    [detailMap, loadDetail, loadingDetailIds],
+    [showNotification, updateDetailItem],
   );
 
   const handleItemKeyDown = useCallback(
@@ -4398,38 +4202,6 @@ export function ActivityView({
     },
     [handleSelectItem],
   );
-
-  const handleCloseItem = useCallback(() => {
-    setOpenItemId((current) => {
-      if (!current) {
-        return current;
-      }
-      const controller = detailControllersRef.current.get(current);
-      if (controller) {
-        controller.abort();
-        detailControllersRef.current.delete(current);
-      }
-      setLoadingDetailIds((loadings) => {
-        if (!loadings.has(current)) {
-          return loadings;
-        }
-        const updated = new Set(loadings);
-        updated.delete(current);
-        return updated;
-      });
-      return null;
-    });
-  }, []);
-
-  useEffect(() => {
-    if (
-      openItemId &&
-      !detailMap[openItemId] &&
-      !loadingDetailIds.has(openItemId)
-    ) {
-      void loadDetail(openItemId);
-    }
-  }, [detailMap, loadDetail, loadingDetailIds, openItemId]);
 
   const canSaveMoreFilters = savedFilters.length < savedFiltersLimit;
 

--- a/src/components/dashboard/attention-view.tsx
+++ b/src/components/dashboard/attention-view.tsx
@@ -21,6 +21,8 @@ import {
   useState,
   useTransition,
 } from "react";
+import { useActivityDetailState } from "@/components/dashboard/hooks/use-activity-detail";
+import { useSyncStream } from "@/components/dashboard/hooks/use-sync-stream";
 import {
   isUnauthorizedResponse,
   retryOnceAfterUnauthorized,
@@ -33,7 +35,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { fetchActivityDetail } from "@/lib/activity/client";
 import type {
   ActivityItem,
   ActivityItemDetail,
@@ -60,7 +61,6 @@ import {
   sortRankingByTotal,
 } from "@/lib/dashboard/attention-summaries";
 import type { DateTimeDisplayFormat } from "@/lib/date-time-format";
-import { subscribeToSyncStream } from "@/lib/sync/client-stream";
 import { cn } from "@/lib/utils";
 import { ActivityDetailOverlay } from "./activity/activity-detail-overlay";
 import { ActivityListItemSummary } from "./activity/activity-list-item-summary";
@@ -378,160 +378,6 @@ function buildReferenceLabel(
     return repoLabel;
   }
   return `${repoLabel}#${number.toString()}`;
-}
-
-function useActivityDetailState() {
-  const [openItemId, setOpenItemId] = useState<string | null>(null);
-  const [detailMap, setDetailMap] = useState<
-    Record<string, ActivityItemDetail | null>
-  >({});
-  const [loadingDetailIds, setLoadingDetailIds] = useState<Set<string>>(
-    () => new Set<string>(),
-  );
-  const controllersRef = useRef<Map<string, AbortController>>(new Map());
-
-  useEffect(() => {
-    return () => {
-      controllersRef.current.forEach((controller) => {
-        controller.abort();
-      });
-      controllersRef.current.clear();
-    };
-  }, []);
-
-  const loadDetail = useCallback(async (id: string) => {
-    if (!id.trim()) {
-      return;
-    }
-
-    setLoadingDetailIds((current) => {
-      if (current.has(id)) {
-        return current;
-      }
-      const next = new Set(current);
-      next.add(id);
-      return next;
-    });
-
-    const existing = controllersRef.current.get(id);
-    existing?.abort();
-
-    const controller = new AbortController();
-    controllersRef.current.set(id, controller);
-
-    try {
-      const detail = await fetchActivityDetail(id, {
-        signal: controller.signal,
-      });
-      setDetailMap((current) => ({
-        ...current,
-        [id]: detail,
-      }));
-    } catch (error) {
-      if ((error as Error).name !== "AbortError") {
-        console.error(error);
-        setDetailMap((current) => ({
-          ...current,
-          [id]: null,
-        }));
-      }
-    } finally {
-      controllersRef.current.delete(id);
-      setLoadingDetailIds((current) => {
-        if (!current.has(id)) {
-          return current;
-        }
-        const next = new Set(current);
-        next.delete(id);
-        return next;
-      });
-    }
-  }, []);
-
-  const selectItem = useCallback(
-    (id: string) => {
-      setOpenItemId((current) => {
-        if (current === id) {
-          const controller = controllersRef.current.get(id);
-          controller?.abort();
-          controllersRef.current.delete(id);
-          setLoadingDetailIds((loadings) => {
-            if (!loadings.has(id)) {
-              return loadings;
-            }
-            const next = new Set(loadings);
-            next.delete(id);
-            return next;
-          });
-          return null;
-        }
-
-        if (current) {
-          const controller = controllersRef.current.get(current);
-          controller?.abort();
-          controllersRef.current.delete(current);
-          setLoadingDetailIds((loadings) => {
-            if (!loadings.has(current)) {
-              return loadings;
-            }
-            const next = new Set(loadings);
-            next.delete(current);
-            return next;
-          });
-        }
-
-        if (!detailMap[id] && !loadingDetailIds.has(id)) {
-          void loadDetail(id);
-        }
-
-        return id;
-      });
-    },
-    [detailMap, loadDetail, loadingDetailIds],
-  );
-
-  const closeItem = useCallback(() => {
-    setOpenItemId((current) => {
-      if (!current) {
-        return current;
-      }
-      const controller = controllersRef.current.get(current);
-      controller?.abort();
-      controllersRef.current.delete(current);
-      setLoadingDetailIds((loadings) => {
-        if (!loadings.has(current)) {
-          return loadings;
-        }
-        const next = new Set(loadings);
-        next.delete(current);
-        return next;
-      });
-      return null;
-    });
-  }, []);
-
-  const updateDetailItem = useCallback((nextItem: ActivityItem) => {
-    setDetailMap((current) => {
-      const existing = current[nextItem.id];
-      if (!existing) {
-        return current;
-      }
-      return {
-        ...current,
-        [nextItem.id]: { ...existing, item: nextItem },
-      };
-    });
-  }, []);
-
-  return {
-    openItemId,
-    detailMap,
-    loadingDetailIds,
-    selectItem,
-    closeItem,
-    updateDetailItem,
-    loadDetail,
-  };
 }
 
 export function FollowUpDetailContent({
@@ -3805,11 +3651,11 @@ export function AttentionView({
     }, 4000);
   }, []);
 
-  useEffect(() => {
-    const updateAutoSyncState = () => {
-      setAutomaticSyncActive(autoSyncRunIdsRef.current.size > 0);
-    };
-    const unsubscribe = subscribeToSyncStream((event) => {
+  useSyncStream(
+    useCallback((event) => {
+      const updateAutoSyncState = () => {
+        setAutomaticSyncActive(autoSyncRunIdsRef.current.size > 0);
+      };
       if (event.type === "run-started" && event.runType === "automatic") {
         if (!autoSyncRunIdsRef.current.has(event.runId)) {
           autoSyncRunIdsRef.current.add(event.runId);
@@ -3831,9 +3677,8 @@ export function AttentionView({
           updateAutoSyncState();
         }
       }
-    });
-    return unsubscribe;
-  }, []);
+    }, []),
+  );
 
   useEffect(() => {
     let canceled = false;

--- a/src/components/dashboard/dashboard-header.tsx
+++ b/src/components/dashboard/dashboard-header.tsx
@@ -6,7 +6,7 @@ import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { subscribeToSyncStream } from "@/lib/sync/client-stream";
+import { useSyncStream } from "@/components/dashboard/hooks/use-sync-stream";
 import { buildUserInitials } from "@/lib/user/initials";
 import { cn } from "@/lib/utils";
 
@@ -108,23 +108,25 @@ export function DashboardHeader({
     };
   }, [fetchNotificationCount]);
 
-  useEffect(() => {
-    if (!userId) {
-      return;
-    }
-    const unsubscribe = subscribeToSyncStream((event) => {
-      if (event.type !== "attention-refresh") {
-        return;
-      }
-      if (
-        event.scope === "all" ||
-        (event.scope === "users" && event.userIds?.includes(userId))
-      ) {
-        void fetchNotificationCount();
-      }
-    });
-    return unsubscribe;
-  }, [fetchNotificationCount, userId]);
+  useSyncStream(
+    useCallback(
+      (event) => {
+        if (!userId) {
+          return;
+        }
+        if (event.type !== "attention-refresh") {
+          return;
+        }
+        if (
+          event.scope === "all" ||
+          (event.scope === "users" && event.userIds?.includes(userId))
+        ) {
+          void fetchNotificationCount();
+        }
+      },
+      [fetchNotificationCount, userId],
+    ),
+  );
 
   const notificationsHref = useMemo(() => {
     if (!userId) {

--- a/src/components/dashboard/dashboard-tabs.tsx
+++ b/src/components/dashboard/dashboard-tabs.tsx
@@ -11,11 +11,10 @@ import {
 import type { Route } from "next";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
-
+import { useCallback, useEffect, useState } from "react";
+import { useSyncStream } from "@/components/dashboard/hooks/use-sync-stream";
 import { TimestampBadge } from "@/components/dashboard/timestamp-badge";
 import type { DateTimeDisplayFormat } from "@/lib/date-time-format";
-import { subscribeToSyncStream } from "@/lib/sync/client-stream";
 import { cn } from "@/lib/utils";
 
 const tabs = [
@@ -50,14 +49,13 @@ export function DashboardTabs({
     setLatestSyncCompletedAt(initialLastSyncCompletedAt ?? null);
   }, [initialLastSyncCompletedAt]);
 
-  useEffect(() => {
-    const unsubscribe = subscribeToSyncStream((event) => {
+  useSyncStream(
+    useCallback((event) => {
       if (event.type === "run-completed" && event.status === "success") {
         setLatestSyncCompletedAt(event.completedAt);
       }
-    });
-    return unsubscribe;
-  }, []);
+    }, []),
+  );
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-3 pb-0">

--- a/src/components/dashboard/hooks/use-activity-detail.ts
+++ b/src/components/dashboard/hooks/use-activity-detail.ts
@@ -1,0 +1,261 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { fetchActivityDetail } from "@/lib/activity/client";
+import type { ActivityItem, ActivityItemDetail } from "@/lib/activity/types";
+
+export type ActivityDetailFetchOptions = {
+  useMentionAi?: boolean;
+};
+
+export type ActivityDetailState = {
+  openItemId: string | null;
+  detailMap: Record<string, ActivityItemDetail | null>;
+  loadingDetailIds: Set<string>;
+  selectItem: (id: string) => void;
+  closeItem: () => void;
+  updateDetailItem: (
+    nextItemOrUpdater:
+      | ActivityItem
+      | { id: string; updater: (item: ActivityItem) => ActivityItem },
+  ) => void;
+  loadDetail: (id: string) => Promise<void>;
+  /** Remove cached details and loading entries for items not in `validIds`. */
+  pruneStaleItems: (validIds: Set<string>) => void;
+};
+
+/**
+ * Manages the detail-overlay lifecycle: fetching detail data, tracking
+ * loading state per item, toggling the open item, and cleaning up
+ * in-flight requests on close or unmount.
+ */
+export function useActivityDetailState(
+  fetchOptions?: ActivityDetailFetchOptions,
+): ActivityDetailState {
+  const [openItemId, setOpenItemId] = useState<string | null>(null);
+  const [detailMap, setDetailMap] = useState<
+    Record<string, ActivityItemDetail | null>
+  >({});
+  const [loadingDetailIds, setLoadingDetailIds] = useState<Set<string>>(
+    () => new Set<string>(),
+  );
+  const controllersRef = useRef<Map<string, AbortController>>(new Map());
+
+  useEffect(() => {
+    return () => {
+      controllersRef.current.forEach((controller) => {
+        controller.abort();
+      });
+      controllersRef.current.clear();
+    };
+  }, []);
+
+  const useMentionAi = fetchOptions?.useMentionAi;
+
+  const loadDetail = useCallback(
+    async (id: string) => {
+      if (!id.trim()) {
+        return;
+      }
+
+      setLoadingDetailIds((current) => {
+        if (current.has(id)) {
+          return current;
+        }
+        const next = new Set(current);
+        next.add(id);
+        return next;
+      });
+
+      const existing = controllersRef.current.get(id);
+      existing?.abort();
+
+      const controller = new AbortController();
+      controllersRef.current.set(id, controller);
+
+      try {
+        const detail = await fetchActivityDetail(id, {
+          signal: controller.signal,
+          useMentionAi,
+        });
+        setDetailMap((current) => ({
+          ...current,
+          [id]: detail,
+        }));
+      } catch (error) {
+        if ((error as Error).name === "AbortError") {
+          return;
+        }
+        console.error(error);
+        setDetailMap((current) => ({
+          ...current,
+          [id]: null,
+        }));
+      } finally {
+        controllersRef.current.delete(id);
+        setLoadingDetailIds((current) => {
+          if (!current.has(id)) {
+            return current;
+          }
+          const next = new Set(current);
+          next.delete(id);
+          return next;
+        });
+      }
+    },
+    [useMentionAi],
+  );
+
+  const selectItem = useCallback(
+    (id: string) => {
+      setOpenItemId((current) => {
+        if (current === id) {
+          const controller = controllersRef.current.get(id);
+          controller?.abort();
+          controllersRef.current.delete(id);
+          setLoadingDetailIds((loadings) => {
+            if (!loadings.has(id)) {
+              return loadings;
+            }
+            const next = new Set(loadings);
+            next.delete(id);
+            return next;
+          });
+          return null;
+        }
+
+        if (current) {
+          const controller = controllersRef.current.get(current);
+          controller?.abort();
+          controllersRef.current.delete(current);
+          setLoadingDetailIds((loadings) => {
+            if (!loadings.has(current)) {
+              return loadings;
+            }
+            const next = new Set(loadings);
+            next.delete(current);
+            return next;
+          });
+        }
+
+        if (!detailMap[id] && !loadingDetailIds.has(id)) {
+          void loadDetail(id);
+        }
+
+        return id;
+      });
+    },
+    [detailMap, loadDetail, loadingDetailIds],
+  );
+
+  const closeItem = useCallback(() => {
+    setOpenItemId((current) => {
+      if (!current) {
+        return current;
+      }
+      const controller = controllersRef.current.get(current);
+      controller?.abort();
+      controllersRef.current.delete(current);
+      setLoadingDetailIds((loadings) => {
+        if (!loadings.has(current)) {
+          return loadings;
+        }
+        const next = new Set(loadings);
+        next.delete(current);
+        return next;
+      });
+      return null;
+    });
+  }, []);
+
+  const updateDetailItem = useCallback(
+    (
+      nextItemOrUpdater:
+        | ActivityItem
+        | { id: string; updater: (item: ActivityItem) => ActivityItem },
+    ) => {
+      if ("updater" in nextItemOrUpdater) {
+        const { id, updater } = nextItemOrUpdater;
+        setDetailMap((current) => {
+          const existing = current[id];
+          if (!existing?.item) {
+            return current;
+          }
+          return {
+            ...current,
+            [id]: { ...existing, item: updater(existing.item) },
+          };
+        });
+      } else {
+        const nextItem = nextItemOrUpdater;
+        setDetailMap((current) => {
+          const existing = current[nextItem.id];
+          if (!existing) {
+            return current;
+          }
+          return {
+            ...current,
+            [nextItem.id]: { ...existing, item: nextItem },
+          };
+        });
+      }
+    },
+    [],
+  );
+
+  const pruneStaleItems = useCallback((validIds: Set<string>) => {
+    setOpenItemId((current) => {
+      if (current && !validIds.has(current)) {
+        const controller = controllersRef.current.get(current);
+        controller?.abort();
+        controllersRef.current.delete(current);
+        return null;
+      }
+      return current;
+    });
+
+    setDetailMap((current) => {
+      const entries = Object.entries(current);
+      if (!entries.length) {
+        return current;
+      }
+      let changed = false;
+      const next: Record<string, ActivityItemDetail | null> = {};
+      for (const [id, detail] of entries) {
+        if (validIds.has(id)) {
+          next[id] = detail;
+        } else {
+          changed = true;
+        }
+      }
+      return changed ? next : current;
+    });
+
+    setLoadingDetailIds((current) => {
+      if (!current.size) {
+        return current;
+      }
+      let changed = false;
+      const next = new Set<string>();
+      for (const id of current) {
+        if (validIds.has(id)) {
+          next.add(id);
+        } else {
+          changed = true;
+        }
+      }
+      return changed ? next : current;
+    });
+  }, []);
+
+  return {
+    openItemId,
+    detailMap,
+    loadingDetailIds,
+    selectItem,
+    closeItem,
+    updateDetailItem,
+    loadDetail,
+    pruneStaleItems,
+  };
+}

--- a/src/components/dashboard/hooks/use-authorized-fetch.ts
+++ b/src/components/dashboard/hooks/use-authorized-fetch.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useCallback } from "react";
+import {
+  isUnauthorizedResponse,
+  retryOnceAfterUnauthorized,
+} from "@/components/dashboard/post-login-auth-recovery";
+
+/**
+ * Returns a function that wraps a fetch call with automatic retry on 401
+ * responses. On the first 401, `router.refresh()` is called to refresh
+ * the server session, and the fetch is retried once.
+ */
+export function useAuthorizedFetch() {
+  const router = useRouter();
+  return useCallback(
+    (execute: () => Promise<Response>) =>
+      retryOnceAfterUnauthorized({
+        execute,
+        refresh: () => {
+          router.refresh();
+        },
+        shouldRetry: isUnauthorizedResponse,
+      }),
+    [router],
+  );
+}

--- a/src/components/dashboard/hooks/use-sync-stream.ts
+++ b/src/components/dashboard/hooks/use-sync-stream.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { useEffect } from "react";
+import { subscribeToSyncStream } from "@/lib/sync/client-stream";
+import type { SyncStreamEvent } from "@/lib/sync/events";
+
+/**
+ * Subscribes to the sync event stream for the lifetime of the calling component.
+ * The listener is re-subscribed whenever the callback identity changes.
+ */
+export function useSyncStream(
+  listener: (event: SyncStreamEvent) => void,
+): void {
+  useEffect(() => {
+    return subscribeToSyncStream(listener);
+  }, [listener]);
+}

--- a/src/components/dashboard/sync-controls.tsx
+++ b/src/components/dashboard/sync-controls.tsx
@@ -2,10 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useEffect, useId, useMemo, useState } from "react";
-import {
-  isUnauthorizedResponse,
-  retryOnceAfterUnauthorized,
-} from "@/components/dashboard/post-login-auth-recovery";
+import { useAuthorizedFetch } from "@/components/dashboard/hooks/use-authorized-fetch";
 import { ReauthModal } from "@/components/dashboard/reauth-modal";
 import { SyncSubTabs } from "@/components/dashboard/sync-subtabs";
 import { Button } from "@/components/ui/button";
@@ -388,6 +385,7 @@ export function SyncControls({
   currentPathname,
 }: SyncControlsProps) {
   const router = useRouter();
+  const authorizedFetch = useAuthorizedFetch();
   const config = status.config;
   const backupInfo = status.backup;
   const backupSchedule = backupInfo.schedule;
@@ -540,18 +538,13 @@ export function SyncControls({
 
     const loadSummary = async () => {
       try {
-        const response = await retryOnceAfterUnauthorized({
-          execute: () =>
-            fetch("/api/activity/cache/refresh", {
-              method: "GET",
-              signal: controller.signal,
-              cache: "no-store",
-            }),
-          refresh: () => {
-            router.refresh();
-          },
-          shouldRetry: isUnauthorizedResponse,
-        });
+        const response = await authorizedFetch(() =>
+          fetch("/api/activity/cache/refresh", {
+            method: "GET",
+            signal: controller.signal,
+            cache: "no-store",
+          }),
+        );
         if (!response.ok) {
           return;
         }
@@ -571,18 +564,13 @@ export function SyncControls({
         }
 
         try {
-          const snapshotResponse = await retryOnceAfterUnauthorized({
-            execute: () =>
-              fetch("/api/activity/snapshot/refresh", {
-                method: "GET",
-                signal: controller.signal,
-                cache: "no-store",
-              }),
-            refresh: () => {
-              router.refresh();
-            },
-            shouldRetry: isUnauthorizedResponse,
-          });
+          const snapshotResponse = await authorizedFetch(() =>
+            fetch("/api/activity/snapshot/refresh", {
+              method: "GET",
+              signal: controller.signal,
+              cache: "no-store",
+            }),
+          );
 
           if (snapshotResponse.ok) {
             const snapshotData =
@@ -627,7 +615,7 @@ export function SyncControls({
       cancelled = true;
       controller.abort();
     };
-  }, [canManageSync, router]);
+  }, [canManageSync, authorizedFetch]);
 
   useEffect(() => {
     if (!canManageSync) {
@@ -640,18 +628,13 @@ export function SyncControls({
 
     const loadAutomationSummary = async () => {
       try {
-        const response = await retryOnceAfterUnauthorized({
-          execute: () =>
-            fetch("/api/activity/status-automation", {
-              method: "GET",
-              signal: controller.signal,
-              cache: "no-store",
-            }),
-          refresh: () => {
-            router.refresh();
-          },
-          shouldRetry: isUnauthorizedResponse,
-        });
+        const response = await authorizedFetch(() =>
+          fetch("/api/activity/status-automation", {
+            method: "GET",
+            signal: controller.signal,
+            cache: "no-store",
+          }),
+        );
         if (!response.ok) {
           return;
         }
@@ -690,7 +673,7 @@ export function SyncControls({
       cancelled = true;
       controller.abort();
     };
-  }, [canManageSync, router]);
+  }, [canManageSync, authorizedFetch]);
 
   const runGroups = useMemo(() => buildRunGroups(status), [status]);
   const primaryLatestRun = useMemo(

--- a/src/components/dashboard/sync-status-panel.tsx
+++ b/src/components/dashboard/sync-status-panel.tsx
@@ -1,20 +1,16 @@
 "use client";
 
 import { AlertCircle, CheckCircle2, Loader2, RefreshCcw } from "lucide-react";
-import { useRouter } from "next/navigation";
 import type { JSX } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import {
-  isUnauthorizedResponse,
-  retryOnceAfterUnauthorized,
-} from "@/components/dashboard/post-login-auth-recovery";
+import { useAuthorizedFetch } from "@/components/dashboard/hooks/use-authorized-fetch";
+import { useSyncStream } from "@/components/dashboard/hooks/use-sync-stream";
 import {
   getCurrentSyncConnectionState,
   type SyncConnectionState,
   subscribeToSyncConnectionState,
   subscribeToSyncHeartbeat,
-  subscribeToSyncStream,
 } from "@/lib/sync/client-stream";
 import type {
   SyncLogStatus,
@@ -280,7 +276,7 @@ function mergeResource(
 }
 
 export function SyncStatusPanel() {
-  const router = useRouter();
+  const authorizedFetch = useAuthorizedFetch();
   const [connectionState, setConnectionState] = useState<SyncConnectionState>(
     () => getCurrentSyncConnectionState(),
   );
@@ -335,20 +331,15 @@ export function SyncStatusPanel() {
     setError(null);
 
     try {
-      const response = await retryOnceAfterUnauthorized({
-        execute: () =>
-          fetch("/api/sync/status", {
-            method: "GET",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            cache: "no-store",
-          }),
-        refresh: () => {
-          router.refresh();
-        },
-        shouldRetry: isUnauthorizedResponse,
-      });
+      const response = await authorizedFetch(() =>
+        fetch("/api/sync/status", {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          cache: "no-store",
+        }),
+      );
 
       if (!response.ok) {
         throw new Error(`Failed to fetch sync status (${response.status})`);
@@ -425,7 +416,7 @@ export function SyncStatusPanel() {
     } finally {
       setIsLoading(false);
     }
-  }, [router]);
+  }, [authorizedFetch]);
 
   const handleStreamEvent = useCallback(
     (event: SyncStreamEvent) => {
@@ -631,10 +622,7 @@ export function SyncStatusPanel() {
     void fetchInitialStatus();
   }, [fetchInitialStatus]);
 
-  useEffect(() => {
-    const unsubscribe = subscribeToSyncStream(handleStreamEvent);
-    return unsubscribe;
-  }, [handleStreamEvent]);
+  useSyncStream(handleStreamEvent);
 
   useEffect(() => {
     const unsubscribe = subscribeToSyncHeartbeat((payload) => {

--- a/src/components/dashboard/use-dashboard-analytics.ts
+++ b/src/components/dashboard/use-dashboard-analytics.ts
@@ -1,11 +1,7 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  isUnauthorizedResponse,
-  retryOnceAfterUnauthorized,
-} from "@/components/dashboard/post-login-auth-recovery";
+import { useAuthorizedFetch } from "@/components/dashboard/hooks/use-authorized-fetch";
 import { PRESETS, type TimePresetKey } from "@/lib/dashboard/date-range";
 import type { DashboardAnalytics, WeekStart } from "@/lib/dashboard/types";
 
@@ -57,7 +53,7 @@ export function useDashboardAnalytics({
   initialAnalytics: DashboardAnalytics;
   defaultRange: { start: string; end: string };
 }): DashboardAnalyticsState {
-  const router = useRouter();
+  const authorizedFetch = useAuthorizedFetch();
   const [analytics, setAnalytics] = useState(initialAnalytics);
   const [timeZone, setTimeZone] = useState(initialAnalytics.timeZone);
   const [weekStart, setWeekStart] = useState<WeekStart>(
@@ -107,17 +103,12 @@ export function useDashboardAnalytics({
           params.set("person", targetFilters.personId);
         }
 
-        const response = await retryOnceAfterUnauthorized({
-          execute: () =>
-            fetch(`/api/dashboard/analytics?${params.toString()}`, {
-              signal: controller.signal,
-              cache: "no-store",
-            }),
-          refresh: () => {
-            router.refresh();
-          },
-          shouldRetry: isUnauthorizedResponse,
-        });
+        const response = await authorizedFetch(() =>
+          fetch(`/api/dashboard/analytics?${params.toString()}`, {
+            signal: controller.signal,
+            cache: "no-store",
+          }),
+        );
         const data = await response.json();
         if (!data.success) {
           throw new Error(
@@ -224,7 +215,7 @@ export function useDashboardAnalytics({
         }
       }
     },
-    [router],
+    [authorizedFetch],
   );
 
   const applyFilters = useCallback(


### PR DESCRIPTION
## Summary

- Add `use-authorized-fetch` hook: wraps `retryOnceAfterUnauthorized` + `router.refresh()` into a reusable callback. Replaces inline wrappers in 5 consumers.
- Add `use-sync-stream` hook: wraps `subscribeToSyncStream` subscribe/cleanup lifecycle. Replaces manual useEffect+unsubscribe in 5 consumers.
- Add `use-activity-detail` hook: manages detail-overlay state (fetch, abort, open/close/toggle, prune stale items). Extracted from `attention-view.tsx` local hook and replaced inline pattern in `activity-view.tsx`.

Net result: −540 lines from view components, +425 lines total (hooks + simplified consumers).

## Test plan

- [ ] `pnpm run typecheck` passes
- [ ] `biome ci --error-on-warnings .` passes
- [ ] `pnpm test` passes (441 tests)
- [ ] No behavioral change — hooks preserve identical logic

Closes #371