### PR TITLE
Remove PLAYWRIGHT_SKIP_DB branching from page loaders

### DIFF
--- a/src/app/dashboard/(tabs)/activity/page.tsx
+++ b/src/app/dashboard/(tabs)/activity/page.tsx
@@ -1,8 +1,4 @@
 import { ActivityView } from "@/components/dashboard/activity-view";
-import {
-  buildActivityFilterOptionsFixture,
-  buildActivityListResultFixture,
-} from "@/components/test-harness/activity-fixtures";
 import { SAVED_FILTER_LIMIT } from "@/lib/activity/filter-store";
 import {
   createSearchParamsFromRecord,
@@ -28,22 +24,14 @@ export default async function ActivityPage({
     createSearchParamsFromRecord(resolvedSearchParams),
   );
 
-  const skipDatabase = process.env.PLAYWRIGHT_SKIP_DB === "1";
-
-  const sessionPromise = readActiveSession();
-  const filterOptionsPromise = skipDatabase
-    ? Promise.resolve(buildActivityFilterOptionsFixture())
-    : getActivityFilterOptions();
-
   const [filterOptions, session] = await Promise.all([
-    filterOptionsPromise,
-    sessionPromise,
+    getActivityFilterOptions(),
+    readActiveSession(),
   ]);
-  const initialData = skipDatabase
-    ? buildActivityListResultFixture()
-    : await getActivityItems(params, {
-        userId: session?.userId ?? null,
-      });
+
+  const initialData = await getActivityItems(params, {
+    userId: session?.userId ?? null,
+  });
 
   return (
     <ActivityView

--- a/src/app/dashboard/(tabs)/analytics/page.tsx
+++ b/src/app/dashboard/(tabs)/analytics/page.tsx
@@ -1,80 +1,25 @@
 import { AnalyticsView } from "@/components/dashboard/analytics-view";
-import { buildDashboardAnalyticsFixture } from "@/components/test-harness/dashboard-fixtures";
-import { buildSyncStatusFixture } from "@/components/test-harness/sync-fixtures";
 import { readActiveSession } from "@/lib/auth/session";
 import { getDashboardAnalytics } from "@/lib/dashboard/analytics";
 import { resolveDashboardRange } from "@/lib/dashboard/date-range";
-import { DEFAULT_HOLIDAY_CALENDAR } from "@/lib/holidays/constants";
 import { fetchSyncConfig } from "@/lib/sync/service";
 import { readUserTimeSettings } from "@/lib/user/time-settings";
 
 export const dynamic = "force-dynamic";
 
 export default async function AnalyticsPage() {
-  const skipDatabase = process.env.PLAYWRIGHT_SKIP_DB === "1";
   const session = await readActiveSession();
-
-  const syncConfig = await (async () => {
-    if (skipDatabase) {
-      return buildSyncStatusFixture().config;
-    }
-
-    try {
-      return await fetchSyncConfig();
-    } catch (error) {
-      console.error(
-        "[github-dashboard] Falling back to fixture sync config",
-        error,
-      );
-      return buildSyncStatusFixture().config;
-    }
-  })();
-
-  const fallbackTimeSettings = {
-    timezone: "UTC",
-    weekStart: "monday" as const,
-    dateTimeFormat: "auto",
-    holidayCalendarCodes: [DEFAULT_HOLIDAY_CALENDAR],
-    organizationHolidayCalendarCodes: [DEFAULT_HOLIDAY_CALENDAR],
-    personalHolidays: [],
-  };
-  const userTimeSettings = await (async () => {
-    if (skipDatabase) {
-      return fallbackTimeSettings;
-    }
-    try {
-      return await readUserTimeSettings(session?.userId ?? null);
-    } catch (error) {
-      console.error(
-        "[github-dashboard] Falling back to default time settings",
-        error,
-      );
-      return fallbackTimeSettings;
-    }
-  })();
+  const syncConfig = await fetchSyncConfig();
+  const userTimeSettings = await readUserTimeSettings(session?.userId ?? null);
 
   const { start, end } = resolveDashboardRange(syncConfig, {
     userTimeSettings,
   });
 
-  const analytics = await (async () => {
-    if (skipDatabase) {
-      return buildDashboardAnalyticsFixture();
-    }
-
-    try {
-      return await getDashboardAnalytics(
-        { start, end },
-        { userId: session?.userId ?? null },
-      );
-    } catch (error) {
-      console.error(
-        "[github-dashboard] Falling back to fixture analytics",
-        error,
-      );
-      return buildDashboardAnalyticsFixture();
-    }
-  })();
+  const analytics = await getDashboardAnalytics(
+    { start, end },
+    { userId: session?.userId ?? null },
+  );
 
   return (
     <AnalyticsView


### PR DESCRIPTION
## Summary

Closes #373

E2E tests now navigate to `/test-harness/*` routes rather than the production dashboard pages, so the `PLAYWRIGHT_SKIP_DB` guard and all test-fixture imports in production code are obsolete.

- `analytics/page.tsx`: removed `PLAYWRIGHT_SKIP_DB` branches and `try/catch`→fixture fallbacks for `syncConfig`, `userTimeSettings`, and `analytics`; removed imports of `buildDashboardAnalyticsFixture`, `buildSyncStatusFixture`
- `activity/page.tsx`: removed `PLAYWRIGHT_SKIP_DB` branches and fixture fallbacks for `filterOptions` and `initialData`; removed imports of `buildActivityListResultFixture`, `buildActivityFilterOptionsFixture`

Both pages now call the real data functions unconditionally and let Next.js error boundaries handle failures.

## Test plan

- `pnpm run typecheck` passes
- `pnpm test` passes (443 tests)
- `biome ci` passes
- E2E: `pnpm test:e2e` — all tests use `/test-harness/*` routes and are unaffected by this change