### PR TITLE
Protect unauthenticated activity and sync APIs

### DIFF
--- a/src/app/api/activity/[id]/project-fields/route.test.ts
+++ b/src/app/api/activity/[id]/project-fields/route.test.ts
@@ -1,8 +1,14 @@
 // @vitest-environment node
 
+import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import type { ActivityItem, ActivityItemDetail } from "@/lib/activity/types";
+import { readActiveSession } from "@/lib/auth/session";
+import type { SessionRecord } from "@/lib/auth/session-store";
+
+vi.mock("@/lib/auth/session", () => ({
+  readActiveSession: vi.fn(),
+}));
 
 const getActivityItemDetailMock =
   vi.fn<(id: string) => Promise<ActivityItemDetail | null>>();
@@ -26,6 +32,8 @@ const refreshActivityItemsSnapshotMock =
 vi.mock("@/lib/activity/snapshot", () => ({
   refreshActivityItemsSnapshot: refreshActivityItemsSnapshotMock,
 }));
+
+const readActiveSessionMock = vi.mocked(readActiveSession);
 
 type RouteHandlers = typeof import("./route");
 
@@ -112,13 +120,83 @@ function buildContext(id: string) {
   };
 }
 
+function buildSession(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  const base = {
+    id: "session-1",
+    userId: "user-1",
+    orgSlug: "acme",
+    orgVerified: true,
+    isAdmin: true,
+    createdAt: new Date("2024-01-01T00:00:00.000Z"),
+    lastSeenAt: new Date("2024-01-01T01:00:00.000Z"),
+    expiresAt: new Date("2024-01-01T12:00:00.000Z"),
+    refreshExpiresAt: new Date("2024-01-02T00:00:00.000Z"),
+    maxExpiresAt: new Date("2024-02-01T00:00:00.000Z"),
+    lastReauthAt: new Date("2024-01-01T00:00:00.000Z"),
+    deviceId: "device-1",
+    ipCountry: "KR",
+  };
+
+  return { ...base, ...overrides };
+}
+
+function buildRequest(
+  path: string,
+  init?: ConstructorParameters<typeof NextRequest>[1],
+) {
+  return new NextRequest(`http://localhost${path}`, init);
+}
+
 describe("PATCH /api/activity/[id]/project-fields", () => {
   let handlers: RouteHandlers;
 
   beforeEach(async () => {
     vi.clearAllMocks();
     refreshActivityItemsSnapshotMock.mockResolvedValue(undefined);
+    readActiveSessionMock.mockResolvedValue(buildSession());
     handlers = await import("./route");
+  });
+
+  it("returns 401 when no session is present", async () => {
+    readActiveSessionMock.mockResolvedValueOnce(null);
+
+    const response = await handlers.PATCH(
+      buildRequest("/api/activity/issue-1/project-fields", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ priority: "P2" }),
+      }),
+      buildContext("issue-1"),
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      success: false,
+      message: "Authentication required.",
+    });
+    expect(getActivityItemDetailMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the session is not admin", async () => {
+    readActiveSessionMock.mockResolvedValueOnce(
+      buildSession({ isAdmin: false }),
+    );
+
+    const response = await handlers.PATCH(
+      buildRequest("/api/activity/issue-1/project-fields", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ priority: "P2" }),
+      }),
+      buildContext("issue-1"),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      success: false,
+      message: "Administrator access is required.",
+    });
+    expect(getActivityItemDetailMock).not.toHaveBeenCalled();
   });
 
   it("updates editable project fields and returns the refreshed item", async () => {
@@ -140,7 +218,7 @@ describe("PATCH /api/activity/[id]/project-fields", () => {
     );
 
     const response = await handlers.PATCH(
-      new Request("http://localhost/api/activity/issue-1/project-fields", {
+      buildRequest("/api/activity/issue-1/project-fields", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -174,7 +252,7 @@ describe("PATCH /api/activity/[id]/project-fields", () => {
     getActivityItemDetailMock.mockResolvedValueOnce(createDetail());
 
     const response = await handlers.PATCH(
-      new Request("http://localhost/api/activity/issue-1/project-fields", {
+      buildRequest("/api/activity/issue-1/project-fields", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ priority: "invalid" }),
@@ -197,7 +275,7 @@ describe("PATCH /api/activity/[id]/project-fields", () => {
     );
 
     const response = await handlers.PATCH(
-      new Request("http://localhost/api/activity/issue-1/project-fields", {
+      buildRequest("/api/activity/issue-1/project-fields", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ priority: "P1" }),
@@ -224,7 +302,7 @@ describe("PATCH /api/activity/[id]/project-fields", () => {
     );
 
     const response = await handlers.PATCH(
-      new Request("http://localhost/api/activity/issue-1/project-fields", {
+      buildRequest("/api/activity/issue-1/project-fields", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -248,7 +326,7 @@ describe("PATCH /api/activity/[id]/project-fields", () => {
 
   it("returns 400 when the issue id is invalid", async () => {
     const response = await handlers.PATCH(
-      new Request("http://localhost/api/activity/%20/project-fields", {
+      buildRequest("/api/activity/%20/project-fields", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ priority: "P1" }),
@@ -267,7 +345,7 @@ describe("PATCH /api/activity/[id]/project-fields", () => {
     getActivityItemDetailMock.mockResolvedValueOnce(null);
 
     const response = await handlers.PATCH(
-      new Request("http://localhost/api/activity/missing/project-fields", {
+      buildRequest("/api/activity/missing/project-fields", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ priority: "P1" }),
@@ -290,7 +368,7 @@ describe("PATCH /api/activity/[id]/project-fields", () => {
     );
 
     const response = await handlers.PATCH(
-      new Request("http://localhost/api/activity/pr-1/project-fields", {
+      buildRequest("/api/activity/pr-1/project-fields", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ priority: "P1" }),
@@ -312,7 +390,46 @@ describe("DELETE /api/activity/[id]/project-fields", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     refreshActivityItemsSnapshotMock.mockResolvedValue(undefined);
+    readActiveSessionMock.mockResolvedValue(buildSession());
     handlers = await import("./route");
+  });
+
+  it("returns 401 when no session is present", async () => {
+    readActiveSessionMock.mockResolvedValueOnce(null);
+
+    const response = await handlers.DELETE(
+      buildRequest("/api/activity/issue-1/project-fields", {
+        method: "DELETE",
+      }),
+      buildContext("issue-1"),
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      success: false,
+      message: "Authentication required.",
+    });
+    expect(clearProjectFieldOverridesMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the session is not admin", async () => {
+    readActiveSessionMock.mockResolvedValueOnce(
+      buildSession({ isAdmin: false }),
+    );
+
+    const response = await handlers.DELETE(
+      buildRequest("/api/activity/issue-1/project-fields", {
+        method: "DELETE",
+      }),
+      buildContext("issue-1"),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      success: false,
+      message: "Administrator access is required.",
+    });
+    expect(clearProjectFieldOverridesMock).not.toHaveBeenCalled();
   });
 
   it("clears overrides and returns the updated item when unlocked", async () => {
@@ -330,7 +447,7 @@ describe("DELETE /api/activity/[id]/project-fields", () => {
     );
 
     const response = await handlers.DELETE(
-      new Request("http://localhost/api/activity/issue-1/project-fields", {
+      buildRequest("/api/activity/issue-1/project-fields", {
         method: "DELETE",
       }),
       buildContext("issue-1"),
@@ -353,7 +470,7 @@ describe("DELETE /api/activity/[id]/project-fields", () => {
     );
 
     const response = await handlers.DELETE(
-      new Request("http://localhost/api/activity/issue-1/project-fields", {
+      buildRequest("/api/activity/issue-1/project-fields", {
         method: "DELETE",
       }),
       buildContext("issue-1"),
@@ -368,7 +485,7 @@ describe("DELETE /api/activity/[id]/project-fields", () => {
 
   it("returns 400 when the issue id is invalid", async () => {
     const response = await handlers.DELETE(
-      new Request("http://localhost/api/activity/%20/project-fields", {
+      buildRequest("/api/activity/%20/project-fields", {
         method: "DELETE",
       }),
       buildContext(" "),
@@ -385,7 +502,7 @@ describe("DELETE /api/activity/[id]/project-fields", () => {
     getActivityItemDetailMock.mockResolvedValueOnce(null);
 
     const response = await handlers.DELETE(
-      new Request("http://localhost/api/activity/missing/project-fields", {
+      buildRequest("/api/activity/missing/project-fields", {
         method: "DELETE",
       }),
       buildContext("missing"),

--- a/src/app/api/activity/[id]/project-fields/route.ts
+++ b/src/app/api/activity/[id]/project-fields/route.ts
@@ -8,10 +8,7 @@ import {
 import { getActivityItemDetail } from "@/lib/activity/service";
 import { refreshActivityItemsSnapshot } from "@/lib/activity/snapshot";
 import type { IssueProjectStatus } from "@/lib/activity/types";
-
-type RouteParams = {
-  params: Promise<{ id: string }>;
-};
+import { adminRoute } from "@/lib/api/route-handler";
 
 type ProjectFieldKey =
   | "priority"
@@ -178,195 +175,199 @@ function isLockedStatus(status: IssueProjectStatus | null) {
   return status === "in_progress" || status === "done" || status === "pending";
 }
 
-export async function PATCH(request: Request, context: RouteParams) {
-  const resolvedParams = await context.params;
-  const rawId = resolvedParams?.id ?? "";
-  const id = decodeURIComponent(rawId.trim());
-  if (!id) {
-    return NextResponse.json({ error: "Invalid issue id." }, { status: 400 });
-  }
-
-  let payload: unknown;
-  try {
-    payload = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid request body." },
-      { status: 400 },
-    );
-  }
-
-  const record = (payload as Record<string, unknown>) ?? {};
-  const providedKeys = (Object.keys(record) as ProjectFieldKey[]).filter(
-    (key) =>
-      key === "priority" ||
-      key === "weight" ||
-      key === "initiationOptions" ||
-      key === "startDate",
-  );
-
-  if (providedKeys.length === 0) {
-    return NextResponse.json(
-      { error: "Missing project field values." },
-      { status: 400 },
-    );
-  }
-
-  const expectedPayloadRaw = record.expected;
-  let expectedPayload: Record<string, unknown> | undefined;
-  if (expectedPayloadRaw !== undefined) {
-    if (
-      expectedPayloadRaw === null ||
-      typeof expectedPayloadRaw !== "object" ||
-      Array.isArray(expectedPayloadRaw)
-    ) {
-      return NextResponse.json(
-        { error: "기대한 값 형식이 올바르지 않아요." },
-        { status: 400 },
-      );
+export const PATCH = adminRoute<{ id: string }>(
+  async (request, _session, context) => {
+    const resolvedParams = await context.params;
+    const rawId = resolvedParams?.id ?? "";
+    const id = decodeURIComponent(rawId.trim());
+    if (!id) {
+      return NextResponse.json({ error: "Invalid issue id." }, { status: 400 });
     }
-    expectedPayload = expectedPayloadRaw as Record<string, unknown>;
-  }
 
-  const detail = await resolveIssueItem(id);
-  if (!detail) {
-    return NextResponse.json({ error: "Issue not found." }, { status: 404 });
-  }
-
-  if (
-    detail.item.issueProjectStatusLocked &&
-    providedKeys.some((key) => key !== "weight")
-  ) {
-    return NextResponse.json(
-      {
-        error: "To-do 프로젝트가 이 값을 관리하고 있어요.",
-        todoStatus: detail.item.issueTodoProjectStatus,
-      },
-      { status: 409 },
-    );
-  }
-
-  const effectiveUpdates: ProjectFieldOverrideUpdate = {};
-
-  for (const key of providedKeys) {
-    let sanitized: string | null;
+    let payload: unknown;
     try {
-      sanitized = sanitizePayloadValue(key, record[key]);
-    } catch (error) {
+      payload = await request.json();
+    } catch {
       return NextResponse.json(
-        { error: (error as Error).message },
+        { error: "Invalid request body." },
         { status: 400 },
       );
     }
 
-    const currentValue = (() => {
-      switch (key) {
-        case "priority":
-          return detail.item.issueTodoProjectPriority;
-        case "weight":
-          return detail.item.issueTodoProjectWeight;
-        case "initiationOptions":
-          return detail.item.issueTodoProjectInitiationOptions;
-        case "startDate":
-          return detail.item.issueTodoProjectStartDate;
-        default:
-          return null;
-      }
-    })();
+    const record = (payload as Record<string, unknown>) ?? {};
+    const providedKeys = (Object.keys(record) as ProjectFieldKey[]).filter(
+      (key) =>
+        key === "priority" ||
+        key === "weight" ||
+        key === "initiationOptions" ||
+        key === "startDate",
+    );
 
-    const normalizedCurrent = normalizeComparison(key, currentValue);
-    const normalizedNext = normalizeComparison(key, sanitized);
-
-    let normalizedExpected: string | null | undefined;
-    try {
-      const expectedEntry = parseExpectedEntry(expectedPayload, key);
-      if (expectedEntry) {
-        normalizedExpected = normalizeComparison(key, expectedEntry.value);
-      }
-    } catch (error) {
+    if (providedKeys.length === 0) {
       return NextResponse.json(
-        { error: (error as Error).message },
+        { error: "Missing project field values." },
         { status: 400 },
       );
     }
 
-    if (normalizedCurrent === normalizedNext) {
-      continue;
+    const expectedPayloadRaw = record.expected;
+    let expectedPayload: Record<string, unknown> | undefined;
+    if (expectedPayloadRaw !== undefined) {
+      if (
+        expectedPayloadRaw === null ||
+        typeof expectedPayloadRaw !== "object" ||
+        Array.isArray(expectedPayloadRaw)
+      ) {
+        return NextResponse.json(
+          { error: "기대한 값 형식이 올바르지 않아요." },
+          { status: 400 },
+        );
+      }
+      expectedPayload = expectedPayloadRaw as Record<string, unknown>;
+    }
+
+    const detail = await resolveIssueItem(id);
+    if (!detail) {
+      return NextResponse.json({ error: "Issue not found." }, { status: 404 });
     }
 
     if (
-      normalizedExpected !== undefined &&
-      normalizedExpected !== normalizedCurrent
+      detail.item.issueProjectStatusLocked &&
+      providedKeys.some((key) => key !== "weight")
     ) {
-      const refreshed = await resolveIssueItem(id);
-      const label = FIELD_LABEL_MAP[key];
       return NextResponse.json(
         {
-          error: `${label} 값이 이미 변경되었어요. 최신 값을 불러왔어요.`,
-          item: refreshed?.item ?? detail.item,
+          error: "To-do 프로젝트가 이 값을 관리하고 있어요.",
+          todoStatus: detail.item.issueTodoProjectStatus,
         },
         { status: 409 },
       );
     }
 
-    switch (key) {
-      case "priority":
-        effectiveUpdates.priority = sanitized;
-        break;
-      case "weight":
-        effectiveUpdates.weight = sanitized;
-        break;
-      case "initiationOptions":
-        effectiveUpdates.initiationOptions = sanitized;
-        break;
-      case "startDate":
-        effectiveUpdates.startDate = sanitized;
-        break;
-      default:
-        break;
+    const effectiveUpdates: ProjectFieldOverrideUpdate = {};
+
+    for (const key of providedKeys) {
+      let sanitized: string | null;
+      try {
+        sanitized = sanitizePayloadValue(key, record[key]);
+      } catch (error) {
+        return NextResponse.json(
+          { error: (error as Error).message },
+          { status: 400 },
+        );
+      }
+
+      const currentValue = (() => {
+        switch (key) {
+          case "priority":
+            return detail.item.issueTodoProjectPriority;
+          case "weight":
+            return detail.item.issueTodoProjectWeight;
+          case "initiationOptions":
+            return detail.item.issueTodoProjectInitiationOptions;
+          case "startDate":
+            return detail.item.issueTodoProjectStartDate;
+          default:
+            return null;
+        }
+      })();
+
+      const normalizedCurrent = normalizeComparison(key, currentValue);
+      const normalizedNext = normalizeComparison(key, sanitized);
+
+      let normalizedExpected: string | null | undefined;
+      try {
+        const expectedEntry = parseExpectedEntry(expectedPayload, key);
+        if (expectedEntry) {
+          normalizedExpected = normalizeComparison(key, expectedEntry.value);
+        }
+      } catch (error) {
+        return NextResponse.json(
+          { error: (error as Error).message },
+          { status: 400 },
+        );
+      }
+
+      if (normalizedCurrent === normalizedNext) {
+        continue;
+      }
+
+      if (
+        normalizedExpected !== undefined &&
+        normalizedExpected !== normalizedCurrent
+      ) {
+        const refreshed = await resolveIssueItem(id);
+        const label = FIELD_LABEL_MAP[key];
+        return NextResponse.json(
+          {
+            error: `${label} 값이 이미 변경되었어요. 최신 값을 불러왔어요.`,
+            item: refreshed?.item ?? detail.item,
+          },
+          { status: 409 },
+        );
+      }
+
+      switch (key) {
+        case "priority":
+          effectiveUpdates.priority = sanitized;
+          break;
+        case "weight":
+          effectiveUpdates.weight = sanitized;
+          break;
+        case "initiationOptions":
+          effectiveUpdates.initiationOptions = sanitized;
+          break;
+        case "startDate":
+          effectiveUpdates.startDate = sanitized;
+          break;
+        default:
+          break;
+      }
     }
-  }
 
-  if (
-    effectiveUpdates.priority === undefined &&
-    effectiveUpdates.weight === undefined &&
-    effectiveUpdates.initiationOptions === undefined &&
-    effectiveUpdates.startDate === undefined
-  ) {
-    return NextResponse.json({ item: detail.item });
-  }
+    if (
+      effectiveUpdates.priority === undefined &&
+      effectiveUpdates.weight === undefined &&
+      effectiveUpdates.initiationOptions === undefined &&
+      effectiveUpdates.startDate === undefined
+    ) {
+      return NextResponse.json({ item: detail.item });
+    }
 
-  await applyProjectFieldOverrides(id, effectiveUpdates);
-  await refreshActivityItemsSnapshot({ ids: [id] });
-  const updated = await resolveIssueItem(id);
-  return NextResponse.json({ item: updated?.item ?? detail.item });
-}
+    await applyProjectFieldOverrides(id, effectiveUpdates);
+    await refreshActivityItemsSnapshot({ ids: [id] });
+    const updated = await resolveIssueItem(id);
+    return NextResponse.json({ item: updated?.item ?? detail.item });
+  },
+);
 
-export async function DELETE(_: Request, context: RouteParams) {
-  const resolvedParams = await context.params;
-  const rawId = resolvedParams?.id ?? "";
-  const id = decodeURIComponent(rawId.trim());
-  if (!id) {
-    return NextResponse.json({ error: "Invalid issue id." }, { status: 400 });
-  }
+export const DELETE = adminRoute<{ id: string }>(
+  async (_request, _session, context) => {
+    const resolvedParams = await context.params;
+    const rawId = resolvedParams?.id ?? "";
+    const id = decodeURIComponent(rawId.trim());
+    if (!id) {
+      return NextResponse.json({ error: "Invalid issue id." }, { status: 400 });
+    }
 
-  const detail = await resolveIssueItem(id);
-  if (!detail) {
-    return NextResponse.json({ error: "Issue not found." }, { status: 404 });
-  }
+    const detail = await resolveIssueItem(id);
+    if (!detail) {
+      return NextResponse.json({ error: "Issue not found." }, { status: 404 });
+    }
 
-  if (isLockedStatus(detail.item.issueTodoProjectStatus)) {
-    return NextResponse.json(
-      {
-        error: "To-do 프로젝트가 이 값을 관리하고 있어요.",
-        todoStatus: detail.item.issueTodoProjectStatus,
-      },
-      { status: 409 },
-    );
-  }
+    if (isLockedStatus(detail.item.issueTodoProjectStatus)) {
+      return NextResponse.json(
+        {
+          error: "To-do 프로젝트가 이 값을 관리하고 있어요.",
+          todoStatus: detail.item.issueTodoProjectStatus,
+        },
+        { status: 409 },
+      );
+    }
 
-  await clearProjectFieldOverrides(id);
-  await refreshActivityItemsSnapshot({ ids: [id] });
-  const updated = await resolveIssueItem(id);
-  return NextResponse.json({ item: updated?.item ?? detail.item });
-}
+    await clearProjectFieldOverrides(id);
+    await refreshActivityItemsSnapshot({ ids: [id] });
+    const updated = await resolveIssueItem(id);
+    return NextResponse.json({ item: updated?.item ?? detail.item });
+  },
+);

--- a/src/app/api/activity/[id]/route.ts
+++ b/src/app/api/activity/[id]/route.ts
@@ -1,10 +1,6 @@
 import { NextResponse } from "next/server";
-
 import { getActivityItemDetail } from "@/lib/activity/service";
-
-type RouteParams = {
-  params: Promise<{ id: string }>;
-};
+import { authenticatedRoute } from "@/lib/api/route-handler";
 
 function parseMentionAi(value: string | null | undefined): boolean | undefined {
   if (!value) {
@@ -23,41 +19,43 @@ function parseMentionAi(value: string | null | undefined): boolean | undefined {
   return undefined;
 }
 
-export async function GET(request: Request, context: RouteParams) {
-  const resolvedParams = await context.params;
-  const rawId = resolvedParams?.id ?? "";
-  const id = decodeURIComponent(rawId.trim());
-  if (!id) {
-    return NextResponse.json(
-      { error: "Invalid activity id." },
-      { status: 400 },
-    );
-  }
-
-  try {
-    const url = new URL(request.url);
-    const mentionParam =
-      parseMentionAi(url.searchParams.get("mentionAi")) ??
-      parseMentionAi(url.searchParams.get("useMentionAi"));
-    const detail = await getActivityItemDetail(
-      id,
-      mentionParam === undefined
-        ? undefined
-        : { useMentionClassifier: mentionParam },
-    );
-    if (!detail) {
+export const GET = authenticatedRoute<{ id: string }>(
+  async (request, _session, context) => {
+    const resolvedParams = await context.params;
+    const rawId = resolvedParams?.id ?? "";
+    const id = decodeURIComponent(rawId.trim());
+    if (!id) {
       return NextResponse.json(
-        { error: "Activity item not found." },
-        { status: 404 },
+        { error: "Invalid activity id." },
+        { status: 400 },
       );
     }
 
-    return NextResponse.json(detail);
-  } catch (error) {
-    console.error("Failed to load activity item", error);
-    return NextResponse.json(
-      { error: "Failed to load activity detail." },
-      { status: 500 },
-    );
-  }
-}
+    try {
+      const url = new URL(request.url);
+      const mentionParam =
+        parseMentionAi(url.searchParams.get("mentionAi")) ??
+        parseMentionAi(url.searchParams.get("useMentionAi"));
+      const detail = await getActivityItemDetail(
+        id,
+        mentionParam === undefined
+          ? undefined
+          : { useMentionClassifier: mentionParam },
+      );
+      if (!detail) {
+        return NextResponse.json(
+          { error: "Activity item not found." },
+          { status: 404 },
+        );
+      }
+
+      return NextResponse.json(detail);
+    } catch (error) {
+      console.error("Failed to load activity item", error);
+      return NextResponse.json(
+        { error: "Failed to load activity detail." },
+        { status: 500 },
+      );
+    }
+  },
+);

--- a/src/app/api/activity/[id]/status/route.test.ts
+++ b/src/app/api/activity/[id]/status/route.test.ts
@@ -1,8 +1,14 @@
 // @vitest-environment node
 
+import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import type { ActivityItem, ActivityItemDetail } from "@/lib/activity/types";
+import { readActiveSession } from "@/lib/auth/session";
+import type { SessionRecord } from "@/lib/auth/session-store";
+
+vi.mock("@/lib/auth/session", () => ({
+  readActiveSession: vi.fn(),
+}));
 
 const ensureSchemaMock = vi.fn();
 vi.mock("@/lib/db", () => ({
@@ -42,6 +48,8 @@ const refreshActivityItemsSnapshotMock =
 vi.mock("@/lib/activity/snapshot", () => ({
   refreshActivityItemsSnapshot: refreshActivityItemsSnapshotMock,
 }));
+
+const readActiveSessionMock = vi.mocked(readActiveSession);
 
 type RouteHandlers = typeof import("./route");
 
@@ -128,6 +136,33 @@ function buildContext(id: string) {
   };
 }
 
+function buildSession(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  const base = {
+    id: "session-1",
+    userId: "user-1",
+    orgSlug: "acme",
+    orgVerified: true,
+    isAdmin: true,
+    createdAt: new Date("2024-01-01T00:00:00.000Z"),
+    lastSeenAt: new Date("2024-01-01T01:00:00.000Z"),
+    expiresAt: new Date("2024-01-01T12:00:00.000Z"),
+    refreshExpiresAt: new Date("2024-01-02T00:00:00.000Z"),
+    maxExpiresAt: new Date("2024-02-01T00:00:00.000Z"),
+    lastReauthAt: new Date("2024-01-01T00:00:00.000Z"),
+    deviceId: "device-1",
+    ipCountry: "KR",
+  };
+
+  return { ...base, ...overrides };
+}
+
+function buildRequest(
+  path: string,
+  init?: ConstructorParameters<typeof NextRequest>[1],
+) {
+  return new NextRequest(`http://localhost${path}`, init);
+}
+
 describe("PATCH /api/activity/[id]/status", () => {
   let handlers: RouteHandlers;
 
@@ -135,7 +170,50 @@ describe("PATCH /api/activity/[id]/status", () => {
     vi.clearAllMocks();
     ensureSchemaMock.mockResolvedValue(undefined);
     refreshActivityItemsSnapshotMock.mockResolvedValue(undefined);
+    readActiveSessionMock.mockResolvedValue(buildSession());
     handlers = await import("./route");
+  });
+
+  it("returns 401 when no session is present", async () => {
+    readActiveSessionMock.mockResolvedValueOnce(null);
+
+    const response = await handlers.PATCH(
+      buildRequest("/api/activity/issue-1/status", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "done" }),
+      }),
+      buildContext("issue-1"),
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      success: false,
+      message: "Authentication required.",
+    });
+    expect(getActivityItemDetailMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the session is not admin", async () => {
+    readActiveSessionMock.mockResolvedValueOnce(
+      buildSession({ isAdmin: false }),
+    );
+
+    const response = await handlers.PATCH(
+      buildRequest("/api/activity/issue-1/status", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "done" }),
+      }),
+      buildContext("issue-1"),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      success: false,
+      message: "Administrator access is required.",
+    });
+    expect(getActivityItemDetailMock).not.toHaveBeenCalled();
   });
 
   it("updates the issue status and returns the refreshed item", async () => {
@@ -147,7 +225,7 @@ describe("PATCH /api/activity/[id]/status", () => {
     );
 
     const response = await handlers.PATCH(
-      new Request("http://localhost/api/activity/issue-1/status", {
+      buildRequest("/api/activity/issue-1/status", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ status: "done" }),
@@ -175,7 +253,7 @@ describe("PATCH /api/activity/[id]/status", () => {
     );
 
     const response = await handlers.PATCH(
-      new Request("http://localhost/api/activity/issue-1/status", {
+      buildRequest("/api/activity/issue-1/status", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ status: "canceled" }),
@@ -205,7 +283,7 @@ describe("PATCH /api/activity/[id]/status", () => {
     );
 
     const response = await handlers.PATCH(
-      new Request("http://localhost/api/activity/issue-1/status", {
+      buildRequest("/api/activity/issue-1/status", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ status: "no_status" }),
@@ -232,7 +310,7 @@ describe("PATCH /api/activity/[id]/status", () => {
     );
 
     const response = await handlers.PATCH(
-      new Request("http://localhost/api/activity/issue-1/status", {
+      buildRequest("/api/activity/issue-1/status", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -260,7 +338,7 @@ describe("PATCH /api/activity/[id]/status", () => {
     );
 
     const response = await handlers.PATCH(
-      new Request("http://localhost/api/activity/issue-1/status", {
+      buildRequest("/api/activity/issue-1/status", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ status: "in_progress" }),
@@ -281,7 +359,7 @@ describe("PATCH /api/activity/[id]/status", () => {
 
   it("returns 400 when the request body cannot be parsed", async () => {
     const response = await handlers.PATCH(
-      new Request("http://localhost/api/activity/issue-1/status", {
+      buildRequest("/api/activity/issue-1/status", {
         method: "PATCH",
         body: "not-json",
       }),
@@ -296,7 +374,7 @@ describe("PATCH /api/activity/[id]/status", () => {
 
   it("returns 400 when the status value is missing or invalid", async () => {
     const response = await handlers.PATCH(
-      new Request("http://localhost/api/activity/issue-1/status", {
+      buildRequest("/api/activity/issue-1/status", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ status: "invalid" }),
@@ -313,7 +391,7 @@ describe("PATCH /api/activity/[id]/status", () => {
 
   it("returns 400 when the expected status value is invalid", async () => {
     const response = await handlers.PATCH(
-      new Request("http://localhost/api/activity/issue-1/status", {
+      buildRequest("/api/activity/issue-1/status", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ status: "todo", expectedStatus: "invalid" }),
@@ -332,7 +410,7 @@ describe("PATCH /api/activity/[id]/status", () => {
     getActivityItemDetailMock.mockResolvedValueOnce(null);
 
     const response = await handlers.PATCH(
-      new Request("http://localhost/api/activity/missing/status", {
+      buildRequest("/api/activity/missing/status", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ status: "todo" }),
@@ -354,7 +432,7 @@ describe("PATCH /api/activity/[id]/status", () => {
     );
 
     const response = await handlers.PATCH(
-      new Request("http://localhost/api/activity/pr-1/status", {
+      buildRequest("/api/activity/pr-1/status", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ status: "todo" }),
@@ -370,7 +448,7 @@ describe("PATCH /api/activity/[id]/status", () => {
 
   it("returns 400 when the issue id is invalid", async () => {
     const response = await handlers.PATCH(
-      new Request("http://localhost/api/activity/%20/status", {
+      buildRequest("/api/activity/%20/status", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ status: "todo" }),
@@ -392,7 +470,46 @@ describe("DELETE /api/activity/[id]/status", () => {
     vi.clearAllMocks();
     ensureSchemaMock.mockResolvedValue(undefined);
     refreshActivityItemsSnapshotMock.mockResolvedValue(undefined);
+    readActiveSessionMock.mockResolvedValue(buildSession());
     handlers = await import("./route");
+  });
+
+  it("returns 401 when no session is present", async () => {
+    readActiveSessionMock.mockResolvedValueOnce(null);
+
+    const response = await handlers.DELETE(
+      buildRequest("/api/activity/issue-1/status", {
+        method: "DELETE",
+      }),
+      buildContext("issue-1"),
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      success: false,
+      message: "Authentication required.",
+    });
+    expect(clearActivityStatusesMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the session is not admin", async () => {
+    readActiveSessionMock.mockResolvedValueOnce(
+      buildSession({ isAdmin: false }),
+    );
+
+    const response = await handlers.DELETE(
+      buildRequest("/api/activity/issue-1/status", {
+        method: "DELETE",
+      }),
+      buildContext("issue-1"),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      success: false,
+      message: "Administrator access is required.",
+    });
+    expect(clearActivityStatusesMock).not.toHaveBeenCalled();
   });
 
   it("clears activity statuses and returns the refreshed item", async () => {
@@ -404,7 +521,7 @@ describe("DELETE /api/activity/[id]/status", () => {
     );
 
     const response = await handlers.DELETE(
-      new Request("http://localhost/api/activity/issue-1/status", {
+      buildRequest("/api/activity/issue-1/status", {
         method: "DELETE",
       }),
       buildContext("issue-1"),
@@ -421,7 +538,7 @@ describe("DELETE /api/activity/[id]/status", () => {
 
   it("returns 400 when the issue id is invalid", async () => {
     const response = await handlers.DELETE(
-      new Request("http://localhost/api/activity/%20/status", {
+      buildRequest("/api/activity/%20/status", {
         method: "DELETE",
       }),
       buildContext(" "),
@@ -438,7 +555,7 @@ describe("DELETE /api/activity/[id]/status", () => {
     getActivityItemDetailMock.mockResolvedValueOnce(null);
 
     const response = await handlers.DELETE(
-      new Request("http://localhost/api/activity/missing/status", {
+      buildRequest("/api/activity/missing/status", {
         method: "DELETE",
       }),
       buildContext("missing"),

--- a/src/app/api/activity/[id]/status/route.ts
+++ b/src/app/api/activity/[id]/status/route.ts
@@ -7,11 +7,8 @@ import {
   recordActivityStatus,
 } from "@/lib/activity/status-store";
 import type { IssueProjectStatus } from "@/lib/activity/types";
+import { adminRoute } from "@/lib/api/route-handler";
 import { ensureSchema } from "@/lib/db";
-
-type RouteParams = {
-  params: Promise<{ id: string }>;
-};
 
 const ALLOWED_STATUSES: IssueProjectStatus[] = [
   "no_status",
@@ -39,108 +36,112 @@ async function resolveIssueItem(id: string) {
   return detail;
 }
 
-export async function PATCH(request: Request, context: RouteParams) {
-  const resolvedParams = await context.params;
-  const rawId = resolvedParams?.id ?? "";
-  const id = decodeURIComponent(rawId.trim());
-  if (!id) {
-    return NextResponse.json({ error: "Invalid issue id." }, { status: 400 });
-  }
+export const PATCH = adminRoute<{ id: string }>(
+  async (request, _session, context) => {
+    const resolvedParams = await context.params;
+    const rawId = resolvedParams?.id ?? "";
+    const id = decodeURIComponent(rawId.trim());
+    if (!id) {
+      return NextResponse.json({ error: "Invalid issue id." }, { status: 400 });
+    }
 
-  let payload: unknown;
-  try {
-    payload = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid request body." },
-      { status: 400 },
-    );
-  }
-
-  const status = (payload as { status?: unknown })?.status;
-  if (!isIssueProjectStatus(status)) {
-    return NextResponse.json(
-      { error: "Missing or invalid status value." },
-      { status: 400 },
-    );
-  }
-
-  const rawExpectedStatus = (payload as { expectedStatus?: unknown })
-    ?.expectedStatus;
-  let expectedStatus: IssueProjectStatus | undefined;
-  if (rawExpectedStatus !== undefined) {
-    if (!isIssueProjectStatus(rawExpectedStatus)) {
+    let payload: unknown;
+    try {
+      payload = await request.json();
+    } catch {
       return NextResponse.json(
-        { error: "Missing or invalid expected status value." },
+        { error: "Invalid request body." },
         { status: 400 },
       );
     }
-    expectedStatus = rawExpectedStatus;
-  }
 
-  const detail = await resolveIssueItem(id);
-  if (!detail) {
-    return NextResponse.json({ error: "Issue not found." }, { status: 404 });
-  }
+    const status = (payload as { status?: unknown })?.status;
+    if (!isIssueProjectStatus(status)) {
+      return NextResponse.json(
+        { error: "Missing or invalid status value." },
+        { status: 400 },
+      );
+    }
 
-  if (detail.item.issueProjectStatusLocked) {
-    return NextResponse.json(
-      {
-        error: "Status managed by the to-do list project.",
-        todoStatus: detail.item.issueTodoProjectStatus,
-      },
-      { status: 409 },
-    );
-  }
+    const rawExpectedStatus = (payload as { expectedStatus?: unknown })
+      ?.expectedStatus;
+    let expectedStatus: IssueProjectStatus | undefined;
+    if (rawExpectedStatus !== undefined) {
+      if (!isIssueProjectStatus(rawExpectedStatus)) {
+        return NextResponse.json(
+          { error: "Missing or invalid expected status value." },
+          { status: 400 },
+        );
+      }
+      expectedStatus = rawExpectedStatus;
+    }
 
-  if (expectedStatus !== undefined) {
-    const currentStatus = detail.item.issueProjectStatus ?? "no_status";
-    if (currentStatus !== expectedStatus) {
-      const refreshed = await resolveIssueItem(id);
+    const detail = await resolveIssueItem(id);
+    if (!detail) {
+      return NextResponse.json({ error: "Issue not found." }, { status: 404 });
+    }
+
+    if (detail.item.issueProjectStatusLocked) {
       return NextResponse.json(
         {
-          error: "이슈 상태가 이미 변경되었어요. 최신 상태를 불러왔어요.",
-          item: refreshed?.item ?? detail.item,
+          error: "Status managed by the to-do list project.",
+          todoStatus: detail.item.issueTodoProjectStatus,
         },
         { status: 409 },
       );
     }
-  }
 
-  if (status === "no_status") {
-    await clearActivityStatuses(id);
-  } else {
-    await recordActivityStatus(id, status);
-  }
+    if (expectedStatus !== undefined) {
+      const currentStatus = detail.item.issueProjectStatus ?? "no_status";
+      if (currentStatus !== expectedStatus) {
+        const refreshed = await resolveIssueItem(id);
+        return NextResponse.json(
+          {
+            error: "이슈 상태가 이미 변경되었어요. 최신 상태를 불러왔어요.",
+            item: refreshed?.item ?? detail.item,
+          },
+          { status: 409 },
+        );
+      }
+    }
 
-  await refreshActivityItemsSnapshot({ ids: [id] });
+    if (status === "no_status") {
+      await clearActivityStatuses(id);
+    } else {
+      await recordActivityStatus(id, status);
+    }
 
-  const updated = await resolveIssueItem(id);
-  if (updated?.item.issueProjectStatusLocked) {
-    await clearProjectFieldOverrides(id);
     await refreshActivityItemsSnapshot({ ids: [id] });
-    const refreshed = await resolveIssueItem(id);
-    return NextResponse.json({ item: refreshed?.item ?? updated.item });
-  }
 
-  return NextResponse.json({ item: updated?.item ?? detail.item });
-}
+    const updated = await resolveIssueItem(id);
+    if (updated?.item.issueProjectStatusLocked) {
+      await clearProjectFieldOverrides(id);
+      await refreshActivityItemsSnapshot({ ids: [id] });
+      const refreshed = await resolveIssueItem(id);
+      return NextResponse.json({ item: refreshed?.item ?? updated.item });
+    }
 
-export async function DELETE(_: Request, context: RouteParams) {
-  const resolvedParams = await context.params;
-  const rawId = resolvedParams?.id ?? "";
-  const id = decodeURIComponent(rawId.trim());
-  if (!id) {
-    return NextResponse.json({ error: "Invalid issue id." }, { status: 400 });
-  }
+    return NextResponse.json({ item: updated?.item ?? detail.item });
+  },
+);
 
-  const detail = await resolveIssueItem(id);
-  if (!detail) {
-    return NextResponse.json({ error: "Issue not found." }, { status: 404 });
-  }
+export const DELETE = adminRoute<{ id: string }>(
+  async (_request, _session, context) => {
+    const resolvedParams = await context.params;
+    const rawId = resolvedParams?.id ?? "";
+    const id = decodeURIComponent(rawId.trim());
+    if (!id) {
+      return NextResponse.json({ error: "Invalid issue id." }, { status: 400 });
+    }
 
-  await clearActivityStatuses(id);
-  await refreshActivityItemsSnapshot({ ids: [id] });
-  const updated = await resolveIssueItem(id);
-  return NextResponse.json({ item: updated?.item ?? detail.item });
-}
+    const detail = await resolveIssueItem(id);
+    if (!detail) {
+      return NextResponse.json({ error: "Issue not found." }, { status: 404 });
+    }
+
+    await clearActivityStatuses(id);
+    await refreshActivityItemsSnapshot({ ids: [id] });
+    const updated = await resolveIssueItem(id);
+    return NextResponse.json({ item: updated?.item ?? detail.item });
+  },
+);

--- a/src/app/api/activity/options/route.ts
+++ b/src/app/api/activity/options/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
-
 import { getActivityFilterOptions } from "@/lib/activity/service";
+import { authenticatedRoute } from "@/lib/api/route-handler";
 
-export async function GET() {
+export const GET = authenticatedRoute(async () => {
   try {
     const options = await getActivityFilterOptions();
     return NextResponse.json(options);
@@ -13,4 +13,4 @@ export async function GET() {
       { status: 500 },
     );
   }
-}
+});

--- a/src/app/api/activity/route.test.ts
+++ b/src/app/api/activity/route.test.ts
@@ -8,6 +8,7 @@ import type {
   ActivityListParams,
   ActivityListResult,
 } from "@/lib/activity/types";
+import type { SessionRecord } from "@/lib/auth/session-store";
 
 vi.mock("@/lib/activity/params", () => ({
   parseActivityListParams: vi.fn(),
@@ -35,10 +36,45 @@ const { getActivityItems, getActivityFilterOptions, getActivityItemDetail } =
   vi.mocked(await import("@/lib/activity/service"));
 const { readActiveSession } = vi.mocked(await import("@/lib/auth/session"));
 
+function buildSession(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  const base = {
+    id: "session-1",
+    userId: "user-1",
+    orgSlug: "acme",
+    orgVerified: true,
+    isAdmin: false,
+    createdAt: new Date("2024-01-01T00:00:00.000Z"),
+    lastSeenAt: new Date("2024-01-01T01:00:00.000Z"),
+    expiresAt: new Date("2024-01-01T12:00:00.000Z"),
+    refreshExpiresAt: new Date("2024-01-02T00:00:00.000Z"),
+    maxExpiresAt: new Date("2024-02-01T00:00:00.000Z"),
+    lastReauthAt: new Date("2024-01-01T00:00:00.000Z"),
+    deviceId: "device-1",
+    ipCountry: "KR",
+  };
+
+  return { ...base, ...overrides };
+}
+
 describe("GET /api/activity", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    readActiveSession.mockResolvedValue(null);
+    readActiveSession.mockResolvedValue(buildSession());
+  });
+
+  it("returns 401 when no session is present", async () => {
+    readActiveSession.mockResolvedValueOnce(null);
+
+    const { GET } = await import("./route");
+    const response = await GET(new Request("http://localhost/api/activity"));
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      success: false,
+      message: "Authentication required.",
+    });
+    expect(parseActivityListParams).not.toHaveBeenCalled();
+    expect(getActivityItems).not.toHaveBeenCalled();
   });
 
   it("returns activity items for parsed params", async () => {
@@ -74,7 +110,7 @@ describe("GET /api/activity", () => {
     expect(body).toEqual(listResult);
     expect(parseActivityListParams).toHaveBeenCalledTimes(1);
     expect(getActivityItems).toHaveBeenCalledWith(parsedParams, {
-      userId: null,
+      userId: "user-1",
     });
   });
 
@@ -94,6 +130,23 @@ describe("GET /api/activity", () => {
 describe("GET /api/activity/options", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    readActiveSession.mockResolvedValue(buildSession());
+  });
+
+  it("returns 401 when no session is present", async () => {
+    readActiveSession.mockResolvedValueOnce(null);
+
+    const { GET } = await import("./options/route");
+    const response = await GET(
+      new Request("http://localhost/api/activity/options"),
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      success: false,
+      message: "Authentication required.",
+    });
+    expect(getActivityFilterOptions).not.toHaveBeenCalled();
   });
 
   it("returns filter options", async () => {
@@ -110,7 +163,9 @@ describe("GET /api/activity/options", () => {
 
     const { GET } = await import("./options/route");
 
-    const response = await GET();
+    const response = await GET(
+      new Request("http://localhost/api/activity/options"),
+    );
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual(options);
@@ -122,7 +177,9 @@ describe("GET /api/activity/options", () => {
 
     const { GET } = await import("./options/route");
 
-    const response = await GET();
+    const response = await GET(
+      new Request("http://localhost/api/activity/options"),
+    );
 
     expect(response.status).toBe(500);
     expect(await response.json()).toEqual({
@@ -134,6 +191,23 @@ describe("GET /api/activity/options", () => {
 describe("GET /api/activity/[id]", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    readActiveSession.mockResolvedValue(buildSession());
+  });
+
+  it("returns 401 when no session is present", async () => {
+    readActiveSession.mockResolvedValueOnce(null);
+
+    const { GET } = await import("./[id]/route");
+    const response = await GET(new Request("http://localhost/api/activity"), {
+      params: Promise.resolve({ id: "activity-1" }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      success: false,
+      message: "Authentication required.",
+    });
+    expect(getActivityItemDetail).not.toHaveBeenCalled();
   });
 
   it("returns 400 for invalid id", async () => {

--- a/src/app/api/activity/route.ts
+++ b/src/app/api/activity/route.ts
@@ -1,17 +1,16 @@
 import { NextResponse } from "next/server";
 import { parseActivityListParams } from "@/lib/activity/params";
 import { getActivityItems } from "@/lib/activity/service";
-import { readActiveSession } from "@/lib/auth/session";
+import { authenticatedRoute } from "@/lib/api/route-handler";
 
-export async function GET(request: Request) {
+export const GET = authenticatedRoute(async (request, session) => {
   const url = new URL(request.url);
   const searchParams = url.searchParams;
   const params = parseActivityListParams(searchParams);
 
   try {
-    const session = await readActiveSession();
     const result = await getActivityItems(params, {
-      userId: session?.userId ?? null,
+      userId: session.userId,
     });
     return NextResponse.json(result);
   } catch (error) {
@@ -21,4 +20,4 @@ export async function GET(request: Request) {
       { status: 500 },
     );
   }
-}
+});

--- a/src/app/api/github/repository/route.test.ts
+++ b/src/app/api/github/repository/route.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { readActiveSession } from "@/lib/auth/session";
+import type { SessionRecord } from "@/lib/auth/session-store";
+import type { RepositorySummary } from "@/lib/github";
+import { fetchRepositorySummary } from "@/lib/github";
+
+vi.mock("@/lib/auth/session", () => ({
+  readActiveSession: vi.fn(),
+}));
+
+vi.mock("@/lib/github", () => ({
+  fetchRepositorySummary: vi.fn(),
+}));
+
+const readActiveSessionMock = vi.mocked(readActiveSession);
+const fetchRepositorySummaryMock = vi.mocked(fetchRepositorySummary);
+
+function buildSession(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  const base = {
+    id: "session-1",
+    userId: "user-1",
+    orgSlug: "acme",
+    orgVerified: true,
+    isAdmin: false,
+    createdAt: new Date("2024-01-01T00:00:00.000Z"),
+    lastSeenAt: new Date("2024-01-01T01:00:00.000Z"),
+    expiresAt: new Date("2024-01-01T12:00:00.000Z"),
+    refreshExpiresAt: new Date("2024-01-02T00:00:00.000Z"),
+    maxExpiresAt: new Date("2024-02-01T00:00:00.000Z"),
+    lastReauthAt: new Date("2024-01-01T00:00:00.000Z"),
+    deviceId: "device-1",
+    ipCountry: "KR",
+  };
+
+  return { ...base, ...overrides };
+}
+
+function buildRequest(body: unknown) {
+  return new Request("http://localhost/api/github/repository", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/github/repository", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    readActiveSessionMock.mockResolvedValue(buildSession());
+  });
+
+  it("returns 401 when no session is present", async () => {
+    readActiveSessionMock.mockResolvedValueOnce(null);
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      new Request("http://localhost/api/github/repository", {
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      success: false,
+      message: "Authentication required.",
+    });
+    expect(fetchRepositorySummaryMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid payloads", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(buildRequest({ owner: "", name: "" }));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      success: false,
+      message: "Invalid request payload.",
+    });
+    expect(fetchRepositorySummaryMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the repository summary when the lookup succeeds", async () => {
+    const summary: RepositorySummary = {
+      name: "next.js",
+      description: "The React Framework",
+      url: "https://github.com/vercel/next.js",
+      stars: 1,
+      forks: 2,
+      openIssues: 3,
+      openPullRequests: 4,
+      defaultBranch: "canary",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    };
+    fetchRepositorySummaryMock.mockResolvedValueOnce(summary);
+
+    const { POST } = await import("./route");
+    const response = await POST(
+      buildRequest({ owner: "vercel", name: "next.js" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchRepositorySummaryMock).toHaveBeenCalledWith(
+      "vercel",
+      "next.js",
+    );
+    expect(await response.json()).toEqual({
+      success: true,
+      repository: summary,
+    });
+  });
+
+  it("returns 400 when the GitHub lookup fails", async () => {
+    fetchRepositorySummaryMock.mockRejectedValueOnce(
+      new Error("Repository vercel/next.js was not found."),
+    );
+
+    const { POST } = await import("./route");
+    const response = await POST(
+      buildRequest({ owner: "vercel", name: "next.js" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      success: false,
+      message: "Repository vercel/next.js was not found.",
+    });
+  });
+});

--- a/src/app/api/github/repository/route.ts
+++ b/src/app/api/github/repository/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
+import { authenticatedRoute } from "@/lib/api/route-handler";
 import { fetchRepositorySummary } from "@/lib/github";
 
 const requestSchema = z.object({
@@ -8,7 +9,7 @@ const requestSchema = z.object({
   name: z.string().min(1, "Repository name is required."),
 });
 
-export async function POST(request: Request) {
+export const POST = authenticatedRoute(async (request) => {
   try {
     const payload = await request.json();
     const { owner, name } = requestSchema.parse(payload);
@@ -39,4 +40,4 @@ export async function POST(request: Request) {
       { status: 500 },
     );
   }
-}
+});

--- a/src/app/api/sync/stream/route.test.ts
+++ b/src/app/api/sync/stream/route.test.ts
@@ -1,13 +1,59 @@
 import { NextRequest } from "next/server";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { readActiveSession } from "@/lib/auth/session";
+import type { SessionRecord } from "@/lib/auth/session-store";
 import { emitSyncEvent } from "@/lib/sync/event-bus";
 import type { SyncStreamEvent } from "@/lib/sync/events";
 
-import { GET } from "./route";
+vi.mock("@/lib/auth/session", () => ({
+  readActiveSession: vi.fn(),
+}));
+
+const readActiveSessionMock = vi.mocked(readActiveSession);
+
+function buildSession(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  const base = {
+    id: "session-1",
+    userId: "user-1",
+    orgSlug: "acme",
+    orgVerified: true,
+    isAdmin: false,
+    createdAt: new Date("2024-01-01T00:00:00.000Z"),
+    lastSeenAt: new Date("2024-01-01T01:00:00.000Z"),
+    expiresAt: new Date("2024-01-01T12:00:00.000Z"),
+    refreshExpiresAt: new Date("2024-01-02T00:00:00.000Z"),
+    maxExpiresAt: new Date("2024-02-01T00:00:00.000Z"),
+    lastReauthAt: new Date("2024-01-01T00:00:00.000Z"),
+    deviceId: "device-1",
+    ipCountry: "KR",
+  };
+
+  return { ...base, ...overrides };
+}
 
 describe("GET /api/sync/stream", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    readActiveSessionMock.mockResolvedValue(buildSession());
+  });
+
+  it("returns 401 when no session is present", async () => {
+    readActiveSessionMock.mockResolvedValueOnce(null);
+    const { GET } = await import("./route");
+
+    const request = new NextRequest("http://localhost/api/sync/stream");
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      success: false,
+      message: "Authentication required.",
+    });
+  });
+
   it("returns a server-sent events stream and forwards sync events", async () => {
+    const { GET } = await import("./route");
     const request = new NextRequest("http://localhost/api/sync/stream");
     const response = await GET(request);
 

--- a/src/app/api/sync/stream/route.ts
+++ b/src/app/api/sync/stream/route.ts
@@ -1,5 +1,4 @@
-import type { NextRequest } from "next/server";
-
+import { authenticatedRoute } from "@/lib/api/route-handler";
 import {
   getSyncSubscriberCount,
   subscribeToSyncEvents,
@@ -26,7 +25,7 @@ function encodeRetry(delayMs: number) {
   return encoder.encode(`retry: ${delayMs}\n\n`);
 }
 
-export async function GET(request: NextRequest) {
+export const GET = authenticatedRoute(async (request) => {
   let cleanup: (() => void) | null = null;
 
   const stream = new ReadableStream<Uint8Array>({
@@ -102,4 +101,4 @@ export async function GET(request: NextRequest) {
       "X-Accel-Buffering": "no",
     },
   });
-}
+});


### PR DESCRIPTION
## Summary
- require authentication for the activity feed, activity detail, activity options, sync stream, and repository lookup routes
- require administrator access for activity status and project field mutation routes
- add route coverage for the new authentication and authorization expectations

## Testing
- pnpm exec biome ci --error-on-warnings .
- pnpm run typecheck
- pnpm exec vitest run src/app/api/activity/route.test.ts 'src/app/api/activity/[id]/status/route.test.ts' 'src/app/api/activity/[id]/project-fields/route.test.ts' src/app/api/sync/stream/route.test.ts src/app/api/github/repository/route.test.ts
- pnpm lint:md

Closes #394