### PR TITLE
Disable debug and test surfaces in production

### DIFF
--- a/src/app/github-test/page.test.tsx
+++ b/src/app/github-test/page.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const notFoundMock = vi.fn(() => {
+  throw new Error("NEXT_NOT_FOUND");
+});
+
+vi.mock("next/navigation", () => ({
+  notFound: notFoundMock,
+}));
+
+describe("GitHubTestPage", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("rejects production requests with notFound", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const GitHubTestPage = (await import("./page")).default;
+
+    await expect(GitHubTestPage()).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(notFoundMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/github-test/page.tsx
+++ b/src/app/github-test/page.tsx
@@ -8,11 +8,14 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { assertDebugSurfaceEnabled } from "@/lib/debug-surface";
 import { fetchViewerSummary } from "@/lib/github";
 
 export const dynamic = "force-dynamic";
 
 export default async function GitHubTestPage() {
+  assertDebugSurfaceEnabled();
+
   const status: {
     error: string | null;
     viewer: Awaited<ReturnType<typeof fetchViewerSummary>> | null;

--- a/src/app/test-harness/auth/session/route.test.ts
+++ b/src/app/test-harness/auth/session/route.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { establishSession } from "@/lib/auth/session";
+import { ensureSchema } from "@/lib/db";
+import { upsertUser } from "@/lib/db/operations";
+
+vi.mock("@/lib/auth/session", () => ({
+  establishSession: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  ensureSchema: vi.fn(),
+}));
+
+vi.mock("@/lib/db/operations", () => ({
+  upsertUser: vi.fn(),
+}));
+
+const establishSessionMock = vi.mocked(establishSession);
+const ensureSchemaMock = vi.mocked(ensureSchema);
+const upsertUserMock = vi.mocked(upsertUser);
+
+describe("GET /test-harness/auth/session", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns 404 in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const { GET } = await import("./route");
+
+    const response = await GET(
+      new Request("http://localhost/test-harness/auth/session"),
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ success: false });
+    expect(ensureSchemaMock).not.toHaveBeenCalled();
+    expect(upsertUserMock).not.toHaveBeenCalled();
+    expect(establishSessionMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/test-harness/auth/session/route.ts
+++ b/src/app/test-harness/auth/session/route.ts
@@ -4,10 +4,10 @@ import { establishSession } from "@/lib/auth/session";
 import { ensureSchema } from "@/lib/db";
 import type { DbActor } from "@/lib/db/operations";
 import { upsertUser } from "@/lib/db/operations";
-
-function allowHarnessAccess() {
-  return process.env.NODE_ENV !== "production";
-}
+import {
+  createDebugSurfaceDeniedResponse,
+  isDebugSurfaceEnabled,
+} from "@/lib/debug-surface";
 
 function buildActor({
   id,
@@ -31,8 +31,8 @@ function buildActor({
 }
 
 export async function GET(request: Request) {
-  if (!allowHarnessAccess()) {
-    return NextResponse.json({ success: false }, { status: 404 });
+  if (!isDebugSurfaceEnabled()) {
+    return createDebugSurfaceDeniedResponse();
   }
 
   const url = new URL(request.url);

--- a/src/app/test-harness/cache/refresh/route.test.ts
+++ b/src/app/test-harness/cache/refresh/route.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ensureActivityCaches } from "@/lib/activity/cache";
+
+vi.mock("@/lib/activity/cache", () => ({
+  ensureActivityCaches: vi.fn(),
+}));
+
+const ensureActivityCachesMock = vi.mocked(ensureActivityCaches);
+
+describe("test harness cache refresh route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns 404 for GET requests in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const { GET } = await import("./route");
+
+    const response = await GET();
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ success: false });
+    expect(ensureActivityCachesMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for POST requests in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const { POST } = await import("./route");
+
+    const response = await POST();
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ success: false });
+    expect(ensureActivityCachesMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/test-harness/cache/refresh/route.ts
+++ b/src/app/test-harness/cache/refresh/route.ts
@@ -1,8 +1,16 @@
 import { NextResponse } from "next/server";
 
 import { ensureActivityCaches } from "@/lib/activity/cache";
+import {
+  createDebugSurfaceDeniedResponse,
+  isDebugSurfaceEnabled,
+} from "@/lib/debug-surface";
 
 async function handleRequest() {
+  if (!isDebugSurfaceEnabled()) {
+    return createDebugSurfaceDeniedResponse();
+  }
+
   const caches = await ensureActivityCaches({ reason: "test-harness" });
   return NextResponse.json({
     success: true,

--- a/src/app/test-harness/layout.test.tsx
+++ b/src/app/test-harness/layout.test.tsx
@@ -1,0 +1,28 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const notFoundMock = vi.fn(() => {
+  throw new Error("NEXT_NOT_FOUND");
+});
+
+vi.mock("next/navigation", () => ({
+  notFound: notFoundMock,
+}));
+
+describe("TestHarnessLayout", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("rejects production requests with notFound", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const TestHarnessLayout = (await import("./layout")).default;
+
+    expect(() => TestHarnessLayout({ children: "content" })).toThrow(
+      "NEXT_NOT_FOUND",
+    );
+    expect(notFoundMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/test-harness/layout.tsx
+++ b/src/app/test-harness/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+
+import { assertDebugSurfaceEnabled } from "@/lib/debug-surface";
+
+export default function TestHarnessLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  assertDebugSurfaceEnabled();
+  return children;
+}

--- a/src/lib/debug-surface.ts
+++ b/src/lib/debug-surface.ts
@@ -1,0 +1,19 @@
+import { notFound } from "next/navigation";
+import { NextResponse } from "next/server";
+
+/**
+ * Debug and test-only surfaces must stay unreachable in production.
+ */
+export function isDebugSurfaceEnabled() {
+  return process.env.NODE_ENV !== "production";
+}
+
+export function assertDebugSurfaceEnabled() {
+  if (!isDebugSurfaceEnabled()) {
+    notFound();
+  }
+}
+
+export function createDebugSurfaceDeniedResponse() {
+  return NextResponse.json({ success: false }, { status: 404 });
+}


### PR DESCRIPTION
## Summary
- block \/github-test in production before any GitHub connectivity checks run
- block \/test-harness\/* pages in production with a shared layout guard
- block test-harness routes in production and add coverage for the expected 404 behavior

## Testing
- pnpm exec vitest run src/app/github-test/page.test.tsx src/app/test-harness/layout.test.tsx src/app/test-harness/auth/session/route.test.ts src/app/test-harness/cache/refresh/route.test.ts
- pnpm exec biome ci --error-on-warnings .
- pnpm run typecheck
- pnpm lint:md

Closes #395