### PR TITLE
Enforce required production auth configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,10 +6,12 @@ GITHUB_TOKEN=ghp_example_token
 GITHUB_ORG=your-org
 
 # GitHub OAuth App credentials (see docs/github-oauth-app.md).
+# Required in production.
 GITHUB_OAUTH_CLIENT_ID=github-oauth-client-id
 GITHUB_OAUTH_CLIENT_SECRET=github-oauth-client-secret
 
 # Organization whose members are allowed to sign in through GitHub OAuth.
+# Required in production so sign-in stays restricted to your organization.
 GITHUB_ALLOWED_ORG=your-org
 # Until an admin selects allowed teams or members in Settings → Organization,
 # only dashboard administrators can sign in.
@@ -24,6 +26,7 @@ DASHBOARD_ADMIN_IDS=login1,login2
 APP_BASE_URL=http://localhost:3000
 
 # Secret used to sign and encrypt session cookies (generate with `openssl rand -hex 32`).
+# Required in production.
 SESSION_SECRET=11111111111111111111111111111111
 
 # PostgreSQL connection string used by the dashboard APIs.

--- a/src/lib/auth/github.test.ts
+++ b/src/lib/auth/github.test.ts
@@ -32,6 +32,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
   process.env = { ...originalEnv };
 });
 
@@ -59,6 +60,23 @@ describe("GitHub OAuth helpers", () => {
     expect(parsed.searchParams.get("scope")).toBe(
       "read:user user:email read:org",
     );
+  });
+
+  test("buildAuthorizeUrl fails safe in production when auth prerequisites are missing", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    process.env.GITHUB_OAUTH_CLIENT_ID = "client-id";
+    process.env.GITHUB_OAUTH_CLIENT_SECRET = "client-secret";
+    process.env.SESSION_SECRET = "a".repeat(32);
+    delete process.env.GITHUB_ALLOWED_ORG;
+
+    const { buildAuthorizeUrl } = await import("./github");
+
+    expect(() =>
+      buildAuthorizeUrl({
+        state: "state-value",
+        redirectUri: "http://localhost/callback",
+      }),
+    ).toThrow(/GITHUB_ALLOWED_ORG/);
   });
 
   test("buildStateCookie sets secure defaults", async () => {
@@ -117,7 +135,8 @@ describe("GitHub OAuth helpers", () => {
     expect(profile.emails).toEqual(["octo@github.com"]);
   });
 
-  test("verifyOrganizationMembership allows when no org is configured", async () => {
+  test("verifyOrganizationMembership allows when no org is configured outside production", async () => {
+    vi.stubEnv("NODE_ENV", "test");
     delete process.env.GITHUB_ALLOWED_ORG;
 
     const { verifyOrganizationMembership } = await import("./github");

--- a/src/lib/auth/github.ts
+++ b/src/lib/auth/github.ts
@@ -1,7 +1,7 @@
 import { isAdminUser } from "@/lib/auth/admin";
 import { ensureSchema } from "@/lib/db";
 import { type DbActor, getSyncConfig, upsertUser } from "@/lib/db/operations";
-import { env } from "@/lib/env";
+import { assertProductionAuthEnv, env } from "@/lib/env";
 
 const GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
 const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
@@ -43,6 +43,8 @@ export type GithubOAuthProfile = {
 };
 
 function requireOAuthConfig(): GithubOAuthConfig {
+  assertProductionAuthEnv();
+
   const clientId = env.GITHUB_OAUTH_CLIENT_ID;
   const clientSecret = env.GITHUB_OAUTH_CLIENT_SECRET;
 
@@ -261,6 +263,8 @@ export async function verifyOrganizationMembership({
   login,
   userId,
 }: VerifyMembershipOptions): Promise<MembershipResult> {
+  assertProductionAuthEnv();
+
   const targetOrg = env.GITHUB_ALLOWED_ORG?.trim();
   if (!targetOrg) {
     return { allowed: true, orgSlug: null };

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -5,12 +5,21 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 describe("env configuration", () => {
   const originalEnv = { ...process.env };
 
+  function setProductionAuthEnv() {
+    vi.stubEnv("NODE_ENV", "production");
+    process.env.GITHUB_ALLOWED_ORG = "acme";
+    process.env.GITHUB_OAUTH_CLIENT_ID = "client-id";
+    process.env.GITHUB_OAUTH_CLIENT_SECRET = "client-secret";
+    process.env.SESSION_SECRET = "a".repeat(32);
+  }
+
   beforeEach(() => {
     vi.resetModules();
     process.env = { ...originalEnv };
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     process.env = { ...originalEnv };
   });
 
@@ -63,5 +72,33 @@ describe("env configuration", () => {
     process.env.ACTIVITY_SAVED_FILTER_LIMIT = "45";
     const { env } = await import("./env");
     expect(env.ACTIVITY_SAVED_FILTER_LIMIT).toBe(45);
+  });
+
+  test.each([
+    "GITHUB_ALLOWED_ORG",
+    "GITHUB_OAUTH_CLIENT_ID",
+    "GITHUB_OAUTH_CLIENT_SECRET",
+    "SESSION_SECRET",
+  ])("throws in production when %s is missing", async (missingKey) => {
+    setProductionAuthEnv();
+    delete process.env[missingKey];
+
+    const { assertProductionAuthEnv } = await import("./env");
+
+    expect(() => assertProductionAuthEnv()).toThrow(
+      new RegExp(`\\b${missingKey}\\b`),
+    );
+  });
+
+  test("does not require production auth settings outside production", async () => {
+    delete process.env.GITHUB_ALLOWED_ORG;
+    delete process.env.GITHUB_OAUTH_CLIENT_ID;
+    delete process.env.GITHUB_OAUTH_CLIENT_SECRET;
+    delete process.env.SESSION_SECRET;
+    vi.stubEnv("NODE_ENV", "test");
+
+    const { assertProductionAuthEnv } = await import("./env");
+
+    expect(() => assertProductionAuthEnv()).not.toThrow();
   });
 });

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -4,6 +4,13 @@ import path from "node:path";
 
 import { z } from "zod";
 
+const PRODUCTION_AUTH_REQUIRED_ENV_KEYS = [
+  "GITHUB_ALLOWED_ORG",
+  "GITHUB_OAUTH_CLIENT_ID",
+  "GITHUB_OAUTH_CLIENT_SECRET",
+  "SESSION_SECRET",
+] as const;
+
 function coerceOptionalString(value: string | null | undefined) {
   if (typeof value !== "string") {
     return null;
@@ -167,6 +174,18 @@ const resolvedBackupDirectory = parsed.DB_BACKUP_DIRECTORY
     : path.resolve(process.cwd(), parsed.DB_BACKUP_DIRECTORY)
   : defaultBackupDirectory;
 
+function formatEnvKeyList(keys: readonly string[]) {
+  if (keys.length <= 1) {
+    return keys[0] ?? "";
+  }
+
+  if (keys.length === 2) {
+    return `${keys[0]} and ${keys[1]}`;
+  }
+
+  return `${keys.slice(0, -1).join(", ")}, and ${keys.at(-1)}`;
+}
+
 export const env = {
   ...parsed,
   SYNC_INTERVAL_MINUTES: parsed.SYNC_INTERVAL_MINUTES ?? 60,
@@ -191,3 +210,18 @@ export const env = {
     : [],
   ACTIVITY_SAVED_FILTER_LIMIT: parsed.ACTIVITY_SAVED_FILTER_LIMIT ?? 30,
 };
+
+export function assertProductionAuthEnv() {
+  if (process.env.NODE_ENV !== "production") {
+    return;
+  }
+
+  const missing = PRODUCTION_AUTH_REQUIRED_ENV_KEYS.filter((key) => !env[key]);
+  if (missing.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    `Production authentication requires ${formatEnvKeyList(missing)} to be set.`,
+  );
+}


### PR DESCRIPTION
## Summary
- add a shared production auth prerequisite check for GITHUB_ALLOWED_ORG, GITHUB_OAUTH_CLIENT_ID, GITHUB_OAUTH_CLIENT_SECRET, and SESSION_SECRET
- enforce that check from the GitHub OAuth helpers so production sign-in fails safe when core auth configuration is incomplete
- document the production-only auth requirements in .env.example and add tests for the fail-safe behavior

## Testing
- pnpm exec vitest run src/lib/env.test.ts src/lib/auth/github.test.ts
- pnpm exec biome ci --error-on-warnings .
- pnpm run typecheck
- pnpm lint:md

Closes #396