### PR TITLE
Add abuse controls and CSRF defenses for authenticated routes

### DIFF
--- a/src/app/api/activity/[id]/resync/route.test.ts
+++ b/src/app/api/activity/[id]/resync/route.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { POST } from "@/app/api/activity/[id]/resync/route";
 import { resyncActivityItem } from "@/lib/activity/item-resync";
+import { resetRateLimitState } from "@/lib/api/rate-limit";
 import { readActiveSession } from "@/lib/auth/session";
 import type { SessionRecord } from "@/lib/auth/session-store";
 
@@ -38,10 +39,18 @@ function buildSession(overrides: Partial<SessionRecord> = {}): SessionRecord {
 function buildRequest(id: string) {
   return new Request(`http://localhost/api/activity/${id}/resync`, {
     method: "POST",
+    headers: {
+      Origin: "http://localhost",
+    },
   });
 }
 
 describe("POST /api/activity/[id]/resync", () => {
+  beforeEach(() => {
+    resetRateLimitState();
+    vi.clearAllMocks();
+  });
+
   it("returns 401 when no session is present", async () => {
     readActiveSessionMock.mockResolvedValueOnce(null);
 
@@ -117,6 +126,58 @@ describe("POST /api/activity/[id]/resync", () => {
     expect(response.status).toBe(500);
     expect(await response.json()).toEqual({
       error: "Failed to load item data from GitHub.",
+    });
+  });
+
+  it("rejects cross-origin requests", async () => {
+    readActiveSessionMock.mockResolvedValueOnce(buildSession());
+
+    const response = await POST(
+      new Request("http://localhost/api/activity/abc/resync", {
+        method: "POST",
+        headers: {
+          Origin: "https://evil.example",
+        },
+      }),
+      {
+        params: Promise.resolve({ id: "abc" }),
+      },
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: "Cross-origin state-changing requests are not allowed.",
+    });
+    expect(resyncActivityItemMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 when the resync rate limit is exceeded", async () => {
+    readActiveSessionMock.mockResolvedValue(buildSession());
+    resyncActivityItemMock.mockResolvedValue({
+      nodeId: "abc",
+      type: "issue",
+    });
+
+    const routeModule = await import("@/app/api/activity/[id]/resync/route");
+    for (
+      let index = 0;
+      index < routeModule.ACTIVITY_RESYNC_RATE_LIMIT_MAX_REQUESTS;
+      index += 1
+    ) {
+      const response = await routeModule.POST(buildRequest("abc"), {
+        params: Promise.resolve({ id: "abc" }),
+      });
+      expect(response.status).toBe(200);
+    }
+
+    const response = await routeModule.POST(buildRequest("abc"), {
+      params: Promise.resolve({ id: "abc" }),
+    });
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("retry-after")).toBeTruthy();
+    expect(await response.json()).toEqual({
+      error: "Too many resync requests. Please try again shortly.",
     });
   });
 });

--- a/src/app/api/activity/[id]/resync/route.ts
+++ b/src/app/api/activity/[id]/resync/route.ts
@@ -1,18 +1,47 @@
 import { NextResponse } from "next/server";
 
 import { resyncActivityItem } from "@/lib/activity/item-resync";
+import {
+  consumeRateLimit,
+  createRetryAfterHeaders,
+} from "@/lib/api/rate-limit";
+import { getMutationRequestViolation } from "@/lib/api/request-guards";
 import { readActiveSession } from "@/lib/auth/session";
 
 type RouteParams = {
   params: Promise<{ id: string }>;
 };
 
-export async function POST(_: Request, context: RouteParams) {
+export const ACTIVITY_RESYNC_RATE_LIMIT_MAX_REQUESTS = 10;
+export const ACTIVITY_RESYNC_RATE_LIMIT_WINDOW_MS = 60_000;
+
+export async function POST(request: Request, context: RouteParams) {
   const session = await readActiveSession();
   if (!session) {
     return NextResponse.json(
       { error: "Authentication required." },
       { status: 401 },
+    );
+  }
+
+  const mutationViolation = getMutationRequestViolation(request);
+  if (mutationViolation) {
+    return NextResponse.json({ error: mutationViolation }, { status: 403 });
+  }
+
+  const rateLimit = consumeRateLimit({
+    scope: "activity-resync",
+    key: session.userId,
+    limit: ACTIVITY_RESYNC_RATE_LIMIT_MAX_REQUESTS,
+    windowMs: ACTIVITY_RESYNC_RATE_LIMIT_WINDOW_MS,
+  });
+  if (!rateLimit.allowed) {
+    return NextResponse.json(
+      { error: "Too many resync requests. Please try again shortly." },
+      {
+        status: 429,
+        headers: createRetryAfterHeaders(rateLimit.retryAfterSeconds),
+      },
     );
   }
 

--- a/src/app/api/github/repository/route.test.ts
+++ b/src/app/api/github/repository/route.test.ts
@@ -2,6 +2,7 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { resetRateLimitState } from "@/lib/api/rate-limit";
 import { readActiveSession } from "@/lib/auth/session";
 import type { SessionRecord } from "@/lib/auth/session-store";
 import type { RepositorySummary } from "@/lib/github";
@@ -41,7 +42,10 @@ function buildSession(overrides: Partial<SessionRecord> = {}): SessionRecord {
 function buildRequest(body: unknown) {
   return new Request("http://localhost/api/github/repository", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      Origin: "http://localhost",
+    },
     body: JSON.stringify(body),
   });
 }
@@ -49,6 +53,7 @@ function buildRequest(body: unknown) {
 describe("POST /api/github/repository", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetRateLimitState();
     readActiveSessionMock.mockResolvedValue(buildSession());
   });
 
@@ -126,6 +131,68 @@ describe("POST /api/github/repository", () => {
     expect(await response.json()).toEqual({
       success: false,
       message: "Repository vercel/next.js was not found.",
+    });
+  });
+
+  it("rejects cross-origin requests", async () => {
+    const { POST } = await import("./route");
+    const response = await POST(
+      new Request("http://localhost/api/github/repository", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "https://evil.example",
+        },
+        body: JSON.stringify({ owner: "vercel", name: "next.js" }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      success: false,
+      message: "Cross-origin state-changing requests are not allowed.",
+    });
+    expect(fetchRepositorySummaryMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 when the repository lookup rate limit is exceeded", async () => {
+    const summary: RepositorySummary = {
+      name: "next.js",
+      description: "The React Framework",
+      url: "https://github.com/vercel/next.js",
+      stars: 1,
+      forks: 2,
+      openIssues: 3,
+      openPullRequests: 4,
+      defaultBranch: "canary",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    };
+    fetchRepositorySummaryMock.mockResolvedValue(summary);
+
+    const { POST, GITHUB_REPOSITORY_RATE_LIMIT_MAX_REQUESTS } = await import(
+      "./route"
+    );
+
+    for (
+      let index = 0;
+      index < GITHUB_REPOSITORY_RATE_LIMIT_MAX_REQUESTS;
+      index += 1
+    ) {
+      const response = await POST(
+        buildRequest({ owner: "vercel", name: "next.js" }),
+      );
+      expect(response.status).toBe(200);
+    }
+
+    const response = await POST(
+      buildRequest({ owner: "vercel", name: "next.js" }),
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("retry-after")).toBeTruthy();
+    expect(await response.json()).toEqual({
+      success: false,
+      message: "Too many repository lookup requests. Please try again shortly.",
     });
   });
 });

--- a/src/app/api/github/repository/route.ts
+++ b/src/app/api/github/repository/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
+import {
+  consumeRateLimit,
+  createRetryAfterHeaders,
+} from "@/lib/api/rate-limit";
 import { authenticatedRoute } from "@/lib/api/route-handler";
 import { fetchRepositorySummary } from "@/lib/github";
 
@@ -9,7 +13,30 @@ const requestSchema = z.object({
   name: z.string().min(1, "Repository name is required."),
 });
 
-export const POST = authenticatedRoute(async (request) => {
+export const GITHUB_REPOSITORY_RATE_LIMIT_MAX_REQUESTS = 20;
+export const GITHUB_REPOSITORY_RATE_LIMIT_WINDOW_MS = 60_000;
+
+export const POST = authenticatedRoute(async (request, session) => {
+  const rateLimit = consumeRateLimit({
+    scope: "github-repository",
+    key: session.userId,
+    limit: GITHUB_REPOSITORY_RATE_LIMIT_MAX_REQUESTS,
+    windowMs: GITHUB_REPOSITORY_RATE_LIMIT_WINDOW_MS,
+  });
+  if (!rateLimit.allowed) {
+    return NextResponse.json(
+      {
+        success: false,
+        message:
+          "Too many repository lookup requests. Please try again shortly.",
+      },
+      {
+        status: 429,
+        headers: createRetryAfterHeaders(rateLimit.retryAfterSeconds),
+      },
+    );
+  }
+
   try {
     const payload = await request.json();
     const { owner, name } = requestSchema.parse(payload);

--- a/src/app/api/sync/config/route.db.test.ts
+++ b/src/app/api/sync/config/route.db.test.ts
@@ -224,6 +224,30 @@ describe("sync config API routes", () => {
     expect(users.map((user) => user.id)).toEqual(["user", "user-1", "user-2"]);
   });
 
+  it("rejects cross-origin configuration updates", async () => {
+    const response = await handlers.PATCH(
+      new NextRequest("http://localhost/api/sync/config", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "https://evil.example",
+        },
+        body: JSON.stringify({
+          orgName: "blocked-org",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      success: false,
+      message: "Cross-origin state-changing requests are not allowed.",
+    });
+
+    const config = await getSyncConfig();
+    expect(config?.org_name).toBe("seed-org");
+  });
+
   it("updates repository maintainers when requested by an admin user", async () => {
     await seedRepository("repo-1", "user");
     await seedRepository("repo-2", "user");

--- a/src/app/api/sync/config/route.ts
+++ b/src/app/api/sync/config/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
+import { getMutationRequestViolation } from "@/lib/api/request-guards";
 import { authenticatedRoute } from "@/lib/api/route-handler";
 import { checkReauthRequired } from "@/lib/auth/reauth-guard";
 import { readActiveSession } from "@/lib/auth/session";
@@ -140,6 +141,14 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json(
       { success: false, message: "Authentication required." },
       { status: 401 },
+    );
+  }
+
+  const mutationViolation = getMutationRequestViolation(request);
+  if (mutationViolation) {
+    return NextResponse.json(
+      { success: false, message: mutationViolation },
+      { status: 403 },
     );
   }
 

--- a/src/app/api/sync/stream/route.test.ts
+++ b/src/app/api/sync/stream/route.test.ts
@@ -3,14 +3,26 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { readActiveSession } from "@/lib/auth/session";
 import type { SessionRecord } from "@/lib/auth/session-store";
-import { emitSyncEvent } from "@/lib/sync/event-bus";
+import { emitSyncEvent, getSyncSubscriberCount } from "@/lib/sync/event-bus";
 import type { SyncStreamEvent } from "@/lib/sync/events";
 
 vi.mock("@/lib/auth/session", () => ({
   readActiveSession: vi.fn(),
 }));
 
+vi.mock("@/lib/sync/event-bus", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/sync/event-bus")>(
+    "@/lib/sync/event-bus",
+  );
+
+  return {
+    ...actual,
+    getSyncSubscriberCount: vi.fn(() => actual.getSyncSubscriberCount()),
+  };
+});
+
 const readActiveSessionMock = vi.mocked(readActiveSession);
+const getSyncSubscriberCountMock = vi.mocked(getSyncSubscriberCount);
 
 function buildSession(overrides: Partial<SessionRecord> = {}): SessionRecord {
   const base = {
@@ -109,5 +121,21 @@ describe("GET /api/sync/stream", () => {
     expect(eventPayload).toContain('"runId":123');
 
     await reader.cancel();
+  });
+
+  it("returns 429 when too many subscribers are already connected", async () => {
+    const { GET, SYNC_STREAM_MAX_SUBSCRIBERS } = await import("./route");
+    getSyncSubscriberCountMock.mockReturnValueOnce(SYNC_STREAM_MAX_SUBSCRIBERS);
+
+    const request = new NextRequest("http://localhost/api/sync/stream");
+    const response = await GET(request);
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("retry-after")).toBe("5");
+    expect(await response.json()).toEqual({
+      success: false,
+      message:
+        "Too many sync stream connections are already active. Please try again shortly.",
+    });
   });
 });

--- a/src/app/api/sync/stream/route.ts
+++ b/src/app/api/sync/stream/route.ts
@@ -10,6 +10,7 @@ export const dynamic = "force-dynamic";
 
 const encoder = new TextEncoder();
 const HEARTBEAT_INTERVAL_MS = 25_000;
+export const SYNC_STREAM_MAX_SUBSCRIBERS = 25;
 
 function encodeEvent(eventName: string, payload: unknown) {
   const data =
@@ -26,6 +27,22 @@ function encodeRetry(delayMs: number) {
 }
 
 export const GET = authenticatedRoute(async (request) => {
+  if (getSyncSubscriberCount() >= SYNC_STREAM_MAX_SUBSCRIBERS) {
+    return Response.json(
+      {
+        success: false,
+        message:
+          "Too many sync stream connections are already active. Please try again shortly.",
+      },
+      {
+        status: 429,
+        headers: {
+          "Retry-After": "5",
+        },
+      },
+    );
+  }
+
   let cleanup: (() => void) | null = null;
 
   const stream = new ReadableStream<Uint8Array>({

--- a/src/lib/api/rate-limit.ts
+++ b/src/lib/api/rate-limit.ts
@@ -1,0 +1,85 @@
+type RateLimitBucket = {
+  count: number;
+  resetAt: number;
+};
+
+type RateLimitGlobal = typeof globalThis & {
+  __githubDashboardRateLimitStore?: Map<string, RateLimitBucket>;
+};
+
+type ConsumeRateLimitParams = {
+  scope: string;
+  key: string;
+  limit: number;
+  windowMs: number;
+  now?: number;
+};
+
+export type RateLimitResult = {
+  allowed: boolean;
+  retryAfterSeconds: number;
+};
+
+function getRateLimitStore() {
+  const globalRef = globalThis as RateLimitGlobal;
+  if (!globalRef.__githubDashboardRateLimitStore) {
+    globalRef.__githubDashboardRateLimitStore = new Map();
+  }
+
+  return globalRef.__githubDashboardRateLimitStore;
+}
+
+function cleanupExpiredEntries(now: number) {
+  const store = getRateLimitStore();
+  for (const [key, bucket] of store.entries()) {
+    if (bucket.resetAt <= now) {
+      store.delete(key);
+    }
+  }
+}
+
+export function consumeRateLimit({
+  scope,
+  key,
+  limit,
+  windowMs,
+  now = Date.now(),
+}: ConsumeRateLimitParams): RateLimitResult {
+  const store = getRateLimitStore();
+  if (store.size >= 1_000) {
+    cleanupExpiredEntries(now);
+  }
+
+  const bucketKey = `${scope}:${key}`;
+  const existingBucket = store.get(bucketKey);
+  if (!existingBucket || existingBucket.resetAt <= now) {
+    store.set(bucketKey, {
+      count: 1,
+      resetAt: now + windowMs,
+    });
+    return { allowed: true, retryAfterSeconds: 0 };
+  }
+
+  if (existingBucket.count >= limit) {
+    return {
+      allowed: false,
+      retryAfterSeconds: Math.max(
+        1,
+        Math.ceil((existingBucket.resetAt - now) / 1000),
+      ),
+    };
+  }
+
+  existingBucket.count += 1;
+  return { allowed: true, retryAfterSeconds: 0 };
+}
+
+export function createRetryAfterHeaders(retryAfterSeconds: number) {
+  return {
+    "Retry-After": String(retryAfterSeconds),
+  };
+}
+
+export function resetRateLimitState() {
+  getRateLimitStore().clear();
+}

--- a/src/lib/api/request-guards.ts
+++ b/src/lib/api/request-guards.ts
@@ -1,0 +1,64 @@
+import { env } from "@/lib/env";
+
+export const CROSS_ORIGIN_MUTATION_MESSAGE =
+  "Cross-origin state-changing requests are not allowed.";
+
+const STATE_CHANGING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const TRUSTED_FETCH_SITES = new Set(["same-origin", "none"]);
+
+export function isStateChangingMethod(method: string) {
+  return STATE_CHANGING_METHODS.has(method.toUpperCase());
+}
+
+function extractOrigin(value: string | null) {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+function resolveTrustedOrigins(request: Request) {
+  const origins = new Set<string>();
+
+  try {
+    origins.add(new URL(request.url).origin);
+  } catch {
+    // Ignore malformed URLs and fall back to APP_BASE_URL when available.
+  }
+
+  const configuredOrigin = extractOrigin(env.APP_BASE_URL ?? null);
+  if (configuredOrigin) {
+    origins.add(configuredOrigin);
+  }
+
+  return origins;
+}
+
+export function getMutationRequestViolation(request: Request) {
+  if (!isStateChangingMethod(request.method)) {
+    return null;
+  }
+
+  const fetchSite = request.headers.get("sec-fetch-site")?.toLowerCase();
+  if (fetchSite && !TRUSTED_FETCH_SITES.has(fetchSite)) {
+    return CROSS_ORIGIN_MUTATION_MESSAGE;
+  }
+
+  const trustedOrigins = resolveTrustedOrigins(request);
+  const origin = extractOrigin(request.headers.get("origin"));
+  if (origin && !trustedOrigins.has(origin)) {
+    return CROSS_ORIGIN_MUTATION_MESSAGE;
+  }
+
+  const refererOrigin = extractOrigin(request.headers.get("referer"));
+  if (!origin && refererOrigin && !trustedOrigins.has(refererOrigin)) {
+    return CROSS_ORIGIN_MUTATION_MESSAGE;
+  }
+
+  return null;
+}

--- a/src/lib/api/route-handler.test.ts
+++ b/src/lib/api/route-handler.test.ts
@@ -1,9 +1,9 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CROSS_ORIGIN_MUTATION_MESSAGE } from "@/lib/api/request-guards";
 import { checkReauthRequired } from "@/lib/auth/reauth-guard";
 import type { ActiveSession } from "@/lib/auth/session";
 import { readActiveSession } from "@/lib/auth/session";
-
 import { adminRoute, authenticatedRoute } from "./route-handler";
 
 vi.mock("@/lib/auth/session", () => ({
@@ -94,6 +94,45 @@ describe("authenticatedRoute", () => {
     expect(response.status).toBe(201);
     expect(await response.json()).toEqual({ data: "value" });
   });
+
+  it("rejects cross-origin state-changing requests", async () => {
+    vi.mocked(readActiveSession).mockResolvedValue(mockSession);
+    const handler = vi.fn(async () => new Response("ok", { status: 200 }));
+    const route = authenticatedRoute(handler);
+
+    const response = await route(
+      new Request("http://localhost/test", {
+        method: "POST",
+        headers: {
+          Origin: "https://evil.example",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      success: false,
+      message: CROSS_ORIGIN_MUTATION_MESSAGE,
+    });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("allows same-origin state-changing requests", async () => {
+    vi.mocked(readActiveSession).mockResolvedValue(mockSession);
+    const handler = vi.fn(async () => new Response("ok", { status: 200 }));
+    const route = authenticatedRoute(handler);
+
+    const request = new Request("http://localhost/test", {
+      method: "POST",
+      headers: {
+        Origin: "http://localhost",
+      },
+    });
+    const response = await route(request);
+
+    expect(response.status).toBe(200);
+    expect(handler).toHaveBeenCalledWith(request, mockSession, undefined);
+  });
 });
 
 // ---- adminRoute ----
@@ -169,6 +208,29 @@ describe("adminRoute", () => {
 
     await route(new NextRequest("http://localhost/test", { method: "POST" }));
 
+    expect(checkReauthRequired).not.toHaveBeenCalled();
+  });
+
+  it("rejects cross-site mutation requests before reaching the handler", async () => {
+    vi.mocked(readActiveSession).mockResolvedValue(adminSession);
+    const handler = vi.fn(async () => new Response("ok", { status: 200 }));
+    const route = adminRoute(handler);
+
+    const response = await route(
+      new NextRequest("http://localhost/test", {
+        method: "POST",
+        headers: {
+          "Sec-Fetch-Site": "cross-site",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      success: false,
+      message: CROSS_ORIGIN_MUTATION_MESSAGE,
+    });
+    expect(handler).not.toHaveBeenCalled();
     expect(checkReauthRequired).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/api/route-handler.ts
+++ b/src/lib/api/route-handler.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-
+import { getMutationRequestViolation } from "@/lib/api/request-guards";
 import type { ReauthAction } from "@/lib/auth/reauth";
 import { isReauthAction } from "@/lib/auth/reauth";
 import { checkReauthRequired } from "@/lib/auth/reauth-guard";
@@ -27,6 +27,10 @@ function forbidden(): NextResponse {
     { success: false, message: "Administrator access is required." },
     { status: 403 },
   );
+}
+
+function crossOriginMutationForbidden(message: string): NextResponse {
+  return NextResponse.json({ success: false, message }, { status: 403 });
 }
 
 function reauthNeeded(): NextResponse {
@@ -66,6 +70,10 @@ export function authenticatedRoute(handler: any): any {
     const session = await readActiveSession();
     if (!session) {
       return unauthorized();
+    }
+    const mutationViolation = getMutationRequestViolation(request);
+    if (mutationViolation) {
+      return crossOriginMutationForbidden(mutationViolation);
     }
     return handler(request, session, context);
   };
@@ -137,6 +145,10 @@ export function adminRoute(reauthActionOrHandler: any, handlerArg?: any): any {
     }
     if (!session.isAdmin) {
       return forbidden();
+    }
+    const mutationViolation = getMutationRequestViolation(request);
+    if (mutationViolation) {
+      return crossOriginMutationForbidden(mutationViolation);
     }
     if (reauthAction) {
       const needsReauth = await checkReauthRequired(


### PR DESCRIPTION
## Summary
- reject cross-origin state-changing requests for authenticated and admin routes before handlers run
- apply the same mutation guard to the manual-auth sync config and activity resync routes
- add targeted abuse controls for repository lookups, activity resyncs, and sync stream subscriptions

## Testing
- `pnpm exec vitest run src/lib/api/route-handler.test.ts src/app/api/github/repository/route.test.ts 'src/app/api/activity/[id]/resync/route.test.ts' src/app/api/sync/stream/route.test.ts`
- `pnpm exec vitest run --config vitest.db.config.ts src/app/api/sync/config/route.db.test.ts`
- `pnpm exec biome ci --error-on-warnings .`
- `pnpm run typecheck`
- `pnpm lint:md`

Closes #404
