### PR TITLE
Add baseline security headers

### DIFF
--- a/docs/security-headers.md
+++ b/docs/security-headers.md
@@ -1,0 +1,41 @@
+# Security Header Policy
+
+The dashboard now applies a single baseline header policy to every route from
+[next.config.ts](../next.config.ts).
+
+## Enforced headers
+
+- `X-Content-Type-Options: nosniff`
+  Prevents MIME sniffing for scripts and styles.
+- `Referrer-Policy: strict-origin-when-cross-origin`
+  Preserves full referrers for same-origin navigation and reduces cross-origin
+  referrers to the origin only.
+- `X-Frame-Options: DENY`
+  Blocks the dashboard from being embedded in frames and reduces clickjacking
+  exposure.
+- `Permissions-Policy`
+  Disables browser capabilities that the dashboard does not use today:
+  accelerometer, camera, geolocation, gyroscope, magnetometer, microphone,
+  payment, and USB.
+- `X-Powered-By`
+  Disabled via `poweredByHeader: false` so deployment details are not exposed by
+  default.
+
+## Content Security Policy status
+
+A full `Content-Security-Policy` is intentionally deferred for now.
+
+The current app uses features that need a more explicit inventory before CSP can
+be enforced safely:
+
+- `next/font/google` injects runtime-managed styles, which usually requires a
+  nonce-based `style-src` policy or a move to self-hosted fonts.
+- The dashboard renders remote user avatar images, so `img-src` needs an
+  explicit allowlist of GitHub-hosted image origins and any custom avatar
+  storage origins.
+- OAuth redirects and any future third-party integrations should be reviewed
+  before locking down `connect-src`, `frame-ancestors`, and related directives.
+
+When CSP work resumes, prefer a nonce-based policy that is verified against the
+production deployment rather than adding a partial allowlist that may break
+auth, fonts, or remote images.

--- a/next.config.test.ts
+++ b/next.config.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import nextConfig, {
+  buildSecurityHeadersConfig,
+  SECURITY_HEADERS,
+  SECURITY_HEADERS_SOURCE,
+} from "./next.config";
+
+describe("next.config security headers", () => {
+  it("applies the security header policy to every route", async () => {
+    const headers = await nextConfig.headers?.();
+
+    expect(headers).toEqual(buildSecurityHeadersConfig());
+    expect(headers).toEqual([
+      {
+        source: SECURITY_HEADERS_SOURCE,
+        headers: SECURITY_HEADERS,
+      },
+    ]);
+  });
+
+  it("defines the expected baseline hardening headers", () => {
+    const headerMap = new Map(
+      SECURITY_HEADERS.map((header) => [header.key, header.value]),
+    );
+
+    expect(headerMap.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(headerMap.get("Referrer-Policy")).toBe(
+      "strict-origin-when-cross-origin",
+    );
+    expect(headerMap.get("X-Frame-Options")).toBe("DENY");
+    expect(headerMap.get("Permissions-Policy")).toBe(
+      "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()",
+    );
+    expect(headerMap.has("Content-Security-Policy")).toBe(false);
+  });
+
+  it("removes the x-powered-by header", () => {
+    expect(nextConfig.poweredByHeader).toBe(false);
+  });
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,54 @@
 import type { NextConfig } from "next";
 
+export const SECURITY_HEADERS_SOURCE = "/:path*";
+
+const PERMISSIONS_POLICY_DIRECTIVES = [
+  "accelerometer=()",
+  "camera=()",
+  "geolocation=()",
+  "gyroscope=()",
+  "magnetometer=()",
+  "microphone=()",
+  "payment=()",
+  "usb=()",
+];
+
+export const SECURITY_HEADERS = [
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff",
+  },
+  {
+    key: "Referrer-Policy",
+    value: "strict-origin-when-cross-origin",
+  },
+  {
+    key: "X-Frame-Options",
+    value: "DENY",
+  },
+  {
+    key: "Permissions-Policy",
+    value: PERMISSIONS_POLICY_DIRECTIVES.join(", "),
+  },
+];
+
+export function buildSecurityHeadersConfig() {
+  return [
+    {
+      source: SECURITY_HEADERS_SOURCE,
+      headers: SECURITY_HEADERS,
+    },
+  ];
+}
+
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   output: "standalone",
   typedRoutes: true,
+  poweredByHeader: false,
+  async headers() {
+    return buildSecurityHeadersConfig();
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- add baseline security headers for every route via next.config.ts
- disable the x-powered-by header and add unit tests for the policy
- document why Content Security Policy is deferred until font and remote image sources are inventoried

## Testing
- pnpm exec biome ci --error-on-warnings .
- pnpm run typecheck
- pnpm lint:md
- pnpm vitest run next.config.test.ts

Closes #405