### PR TITLE
Document sync stream abuse controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,8 +238,10 @@ repeats the same steps for each day slice in the requested range.
   re-opens.
 - No extra libraries are required—the server uses the built-in Next.js App
   Router streaming response API, and the browser relies on native `EventSource`
-  with automatic reconnection. Expect a single SSE connection per browser tab
-  (~50 concurrent clients are well within the Node runtime budget).
+  with automatic reconnection. Expect a single SSE connection per browser tab.
+  The server currently allows up to 25 concurrent sync stream subscribers and
+  returns `429 Too Many Requests` with `Retry-After: 5` when that cap is
+  reached.
 
 ### Activity filters and optional people chips
 


### PR DESCRIPTION
## Summary
- update the README sync stream section to match the implemented SSE subscriber cap
- document the 429 and Retry-After behavior when the stream connection limit is reached

## Testing
- pnpm lint:md

Closes #398