### PR TITLE
Ignore TypeScript 6+ in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,9 @@ updates:
       - dependency-name: "@types/node"
         versions:
           - ">=25"
+      - dependency-name: "typescript"
+        versions:
+          - ">=6"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- Add `typescript >= 6` to the Dependabot ignore list to prevent upgrade PRs until we're ready to adopt it.