### PR TITLE
Fix date picker Clear button crash in custom mode

### DIFF
--- a/src/components/dashboard/dashboard-filter-panel.tsx
+++ b/src/components/dashboard/dashboard-filter-panel.tsx
@@ -241,6 +241,7 @@ export function DashboardFilterPanel({
                       ),
                     }))
                   }
+                  showClear={false}
                   pickerButtonLabel="달력 열기"
                 />
               </div>
@@ -262,6 +263,7 @@ export function DashboardFilterPanel({
                       ),
                     }))
                   }
+                  showClear={false}
                   pickerButtonLabel="달력 열기"
                 />
               </div>

--- a/src/components/ui/picker-input.tsx
+++ b/src/components/ui/picker-input.tsx
@@ -29,6 +29,8 @@ type PickerInputProps = Omit<ComponentPropsWithoutRef<"input">, "type"> & {
   iconButtonClassName?: string;
   pickerButtonLabel?: string;
   onValueChange?: (value: string) => void;
+  /** Show the Clear button inside the calendar panel. @default true */
+  showClear?: boolean;
 };
 
 const WEEKDAY_LABELS = [
@@ -148,6 +150,7 @@ export const PickerInput = forwardRef<HTMLInputElement, PickerInputProps>(
       lang,
       onChange,
       onValueChange,
+      showClear = true,
       ...props
     },
     forwardedRef,
@@ -257,7 +260,6 @@ export const PickerInput = forwardRef<HTMLInputElement, PickerInputProps>(
       const synthetic = buildSyntheticEvent(target, "");
       onChange?.(synthetic);
       onValueChange?.("");
-      setCalendarOpen(false);
       if (type === "datetime-local") {
         setTimeValue("00:00");
       }
@@ -411,13 +413,17 @@ export const PickerInput = forwardRef<HTMLInputElement, PickerInputProps>(
             </div>
           ) : null}
           <div className="mt-3 flex items-center justify-between">
-            <button
-              type="button"
-              className="text-xs text-muted-foreground hover:text-foreground"
-              onClick={handleClearDate}
-            >
-              Clear
-            </button>
+            {showClear ? (
+              <button
+                type="button"
+                className="text-xs text-muted-foreground hover:text-foreground"
+                onClick={handleClearDate}
+              >
+                Clear
+              </button>
+            ) : (
+              <span />
+            )}
             <button
               type="button"
               className="text-xs text-primary hover:underline"


### PR DESCRIPTION
## Summary
- People 탭의 사용자 지정 기간 모드에서 date picker Clear 버튼 클릭 시 `Uncaught Error: Invalid date input value.` 발생하던 문제 수정
- `PickerInput`에 `showClear` prop 추가 (기본값 `true`), 날짜가 항상 필수인 `DashboardFilterPanel`에서만 `showClear={false}`로 Clear 버튼 숨김
- Clear 후 캘린더가 닫히던 동작 제거 — 값을 비운 뒤 바로 다른 날짜를 고를 수 있도록 개선

## Test plan
- [x] Biome lint/format 통과
- [x] TypeScript 타입 체크 통과
- [x] Dashboard 컴포넌트 테스트 145개 전체 통과
- [x] People 탭 → 사용자 지정 기간 → 시작일/종료일 캘린더에 Clear 버튼이 보이지 않는지 확인
- [x] 다른 PickerInput 사용처 (sync, settings 등)에서 Clear 버튼이 정상 동작하는지 확인
- [x] Clear 클릭 후 캘린더가 열린 상태로 유지되는지 확인

Closes #412