### PR TITLE
Replace pnpm/action-setup with corepack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: 10.30.3
+      - name: Enable corepack
+        run: corepack enable pnpm
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -80,10 +78,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: 10.30.3
+      - name: Enable corepack
+        run: corepack enable pnpm
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- Replace `pnpm/action-setup@v5` with `corepack enable pnpm` in CI workflow.
- The pnpm version is read from the `packageManager` field in `package.json` — no more duplicating the version in the workflow file.

## Why not action-setup v6?
`pnpm/action-setup@v6` installs pnpm via npm, which bundles a YAML parser that rejects `pnpm-lock.yaml` v9.0 format with `ERR_PNPM_BROKEN_LOCKFILE`. Additionally, `actions/setup-node@v6` rewrites the lockfile when its built-in `package-manager-cache` detects the npm-installed pnpm.

Corepack installs the correct standalone binary directly, sidestepping both issues.

Supersedes #441

## Test plan
- [x] CI check job passes (lint, typecheck, markdownlint)
- [x] CI test job passes (unit, db integration, Playwright E2E)
- [x] CI image-build job passes