### PR TITLE
Fix reviewParticipation to compute responded/requested ratio

### DIFF
--- a/src/components/dashboard/metric-tooltips.ts
+++ b/src/components/dashboard/metric-tooltips.ts
@@ -51,7 +51,8 @@ export const individualMetricTooltips = {
     "이 구성원이 리뷰 요청을 받은 후 첫 응답(리뷰 제출, 댓글, 리액션 포함)까지 걸린 평균 시간입니다. 주말과 지정 휴일에 발생한 응답은 0시간으로 계산되며 Dependabot이 생성한 Pull Request는 제외됩니다.",
   reviewCoverage:
     "선택한 기간 동안 머지된 PR 가운데 이 구성원이 리뷰에 참여한 PR 비율입니다. (리뷰한 PR 수 ÷ 동일 기간 머지된 PR 수) Dependabot이 생성한 Pull Request는 제외됩니다.",
-  reviewParticipation: "이 구성원의 리뷰 참여 비율입니다.",
+  reviewParticipation:
+    "이 구성원에게 요청된 리뷰 중 응답한 비율입니다. Dependabot PR은 제외됩니다.",
   discussionComments: "이슈와 PR에서 남긴 코멘트 개수입니다.",
   parentIssueResolutionTime:
     "이 구성원이 담당한 부모 이슈의 평균 해결 시간입니다.",

--- a/src/lib/dashboard/analytics.review-participation.metrics.db.test.ts
+++ b/src/lib/dashboard/analytics.review-participation.metrics.db.test.ts
@@ -216,7 +216,11 @@ function computeExpectedParticipation({
             entry.submittedAt === undefined
               ? mergedMs
               : new Date(entry.submittedAt).getTime();
-          if (!Number.isNaN(submittedMs) && submittedMs >= startMs && submittedMs <= endMs) {
+          if (
+            !Number.isNaN(submittedMs) &&
+            submittedMs >= startMs &&
+            submittedMs <= endMs
+          ) {
             totalResponded++;
             if (entry.reviewerId === targetReviewerId) {
               individualResponded++;

--- a/src/lib/dashboard/analytics.review-participation.metrics.db.test.ts
+++ b/src/lib/dashboard/analytics.review-participation.metrics.db.test.ts
@@ -9,9 +9,11 @@ import {
   type DbPullRequest,
   type DbRepository,
   type DbReview,
+  type DbReviewRequest,
   upsertPullRequest,
   upsertRepository,
   upsertReview,
+  upsertReviewRequest,
   upsertUser,
 } from "@/lib/db/operations";
 import {
@@ -27,7 +29,10 @@ const PERIODS = PERIOD_KEYS;
 
 type ReviewerSpec = {
   reviewerId: string;
+  /** undefined = use default (responded); null = no review submitted */
   submittedAt?: string | null;
+  /** Whether a review_request exists for this reviewer. Default: true */
+  requested?: boolean;
 };
 
 type ParticipationSpec = {
@@ -77,7 +82,7 @@ function buildPullRequest({
   };
 }
 
-async function insertReviews({
+async function insertReviewsAndRequests({
   pullRequestId,
   reviewers,
   defaultSubmittedAt,
@@ -91,24 +96,37 @@ async function insertReviews({
   }
 
   await Promise.all(
-    reviewers.map((entry, index) => {
-      const review: DbReview = {
-        id: `${pullRequestId}-review-${index + 1}`,
-        pullRequestId,
-        authorId: entry.reviewerId,
-        state: entry.submittedAt === null ? "COMMENTED" : "APPROVED",
-        submittedAt:
-          entry.submittedAt === undefined
-            ? defaultSubmittedAt
-            : entry.submittedAt,
-        raw: {},
-      } satisfies DbReview;
+    reviewers.flatMap((entry, index) => {
+      const tasks: Promise<void>[] = [];
 
-      if (entry.submittedAt === null) {
-        review.submittedAt = null;
+      const requested = entry.requested !== false;
+      if (requested) {
+        const reviewRequest: DbReviewRequest = {
+          id: `${pullRequestId}-rr-${index + 1}`,
+          pullRequestId,
+          reviewerId: entry.reviewerId,
+          requestedAt: hoursBefore(defaultSubmittedAt, 4),
+          raw: {},
+        };
+        tasks.push(upsertReviewRequest(reviewRequest));
       }
 
-      return upsertReview(review);
+      if (entry.submittedAt !== null) {
+        const review: DbReview = {
+          id: `${pullRequestId}-review-${index + 1}`,
+          pullRequestId,
+          authorId: entry.reviewerId,
+          state: "APPROVED",
+          submittedAt:
+            entry.submittedAt === undefined
+              ? defaultSubmittedAt
+              : entry.submittedAt,
+          raw: {},
+        };
+        tasks.push(upsertReview(review));
+      }
+
+      return tasks;
     }),
   );
 }
@@ -127,16 +145,6 @@ type ParticipationExpectations = Record<
     individual: number | null;
   }
 >;
-
-function _subtractRange(
-  previousOfStart: Date,
-  previousOfEnd: Date,
-): PeriodRange {
-  const duration = previousOfEnd.getTime() - previousOfStart.getTime();
-  const end = new Date(previousOfStart.getTime() - 1);
-  const start = new Date(end.getTime() - duration);
-  return { start, end };
-}
 
 function buildDatePeriodRanges(): PeriodRanges {
   const isoRanges = buildIsoPeriodRanges(
@@ -166,14 +174,21 @@ function computeExpectedParticipation({
 }): ParticipationExpectations {
   const results = {} as ParticipationExpectations;
 
+  let totalRequested = 0;
+  let totalResponded = 0;
+  let individualRequested = 0;
+  let individualResponded = 0;
+
   for (const period of PERIODS) {
     const specs = periodSpecs[period] ?? [];
     const range = ranges[period];
     const startMs = range.start.getTime();
     const endMs = range.end.getTime();
 
-    const orgCounts: number[] = [];
-    const individualCounts: number[] = [];
+    totalRequested = 0;
+    totalResponded = 0;
+    individualRequested = 0;
+    individualResponded = 0;
 
     for (const spec of specs) {
       if (spec.authorId === dependabotId) {
@@ -188,47 +203,38 @@ function computeExpectedParticipation({
         continue;
       }
 
-      const uniqueReviewers = new Set<string>();
-      let reviewerParticipated = false;
-
       for (const entry of spec.reviewers) {
-        if (entry.submittedAt === null) {
+        const requested = entry.requested !== false;
+        if (!requested) {
           continue;
         }
 
-        const submittedMs =
-          entry.submittedAt === undefined
-            ? mergedMs
-            : new Date(entry.submittedAt).getTime();
-        if (Number.isNaN(submittedMs)) {
-          continue;
-        }
-        if (submittedMs < startMs || submittedMs > endMs) {
-          continue;
+        totalRequested++;
+
+        if (entry.submittedAt !== null) {
+          const submittedMs =
+            entry.submittedAt === undefined
+              ? mergedMs
+              : new Date(entry.submittedAt).getTime();
+          if (!Number.isNaN(submittedMs) && submittedMs >= startMs && submittedMs <= endMs) {
+            totalResponded++;
+            if (entry.reviewerId === targetReviewerId) {
+              individualResponded++;
+            }
+          }
         }
 
-        uniqueReviewers.add(entry.reviewerId);
         if (entry.reviewerId === targetReviewerId) {
-          reviewerParticipated = true;
+          individualRequested++;
         }
-      }
-
-      const count = uniqueReviewers.size;
-      orgCounts.push(count);
-
-      if (reviewerParticipated) {
-        individualCounts.push(count);
       }
     }
 
     const organization =
-      orgCounts.length > 0
-        ? orgCounts.reduce((sum, value) => sum + value, 0) / orgCounts.length
-        : null;
+      totalRequested > 0 ? totalResponded / totalRequested : null;
     const individual =
-      individualCounts.length > 0
-        ? individualCounts.reduce((sum, value) => sum + value, 0) /
-          individualCounts.length
+      individualRequested > 0
+        ? individualResponded / individualRequested
         : null;
 
     results[period] = { organization, individual };
@@ -447,7 +453,7 @@ describe("analytics review participation metrics", () => {
               number,
             });
             await upsertPullRequest(pullRequest);
-            await insertReviews({
+            await insertReviewsAndRequests({
               pullRequestId: pullRequest.id,
               reviewers: spec.reviewers,
               defaultSubmittedAt: spec.mergedAt,
@@ -468,7 +474,7 @@ describe("analytics review participation metrics", () => {
           number: outOfRangeNumber,
         });
         await upsertPullRequest(outOfRangePull);
-        await insertReviews({
+        await insertReviewsAndRequests({
           pullRequestId: outOfRangePull.id,
           reviewers: [
             { reviewerId: reviewer.id },

--- a/src/lib/dashboard/analytics/individual.ts
+++ b/src/lib/dashboard/analytics/individual.ts
@@ -367,29 +367,31 @@ export async function fetchIndividualCoverageMetrics(
          AND pr.github_merged_at BETWEEN $2 AND $3
          AND ${DEPENDABOT_FILTER}
      ),
-     participation AS (
-       SELECT
-         pr.id,
-         COUNT(DISTINCT r.author_id) FILTER (WHERE r.github_submitted_at BETWEEN $2 AND $3) AS reviewer_count
-       FROM pull_requests pr
-       LEFT JOIN reviews r ON r.pull_request_id = pr.id
-       WHERE pr.id IN (SELECT id FROM prs_in_range)
-       GROUP BY pr.id
+     person_requests AS (
+       SELECT rr.id
+       FROM review_requests rr
+       JOIN prs_in_range pr ON pr.id = rr.pull_request_id
+       WHERE rr.reviewer_id = $1
+         AND rr.requested_at BETWEEN $2 AND $3
      ),
-     person_participation AS (
-       SELECT
-         pr.id,
-         COUNT(DISTINCT r.author_id) FILTER (WHERE r.github_submitted_at BETWEEN $2 AND $3) AS reviewer_count
-       FROM pull_requests pr
-       JOIN reviews r ON r.pull_request_id = pr.id
-       WHERE pr.id IN (SELECT pull_request_id FROM reviewer_prs)
-       GROUP BY pr.id
+     person_responses AS (
+       SELECT DISTINCT rr.id
+       FROM review_requests rr
+       JOIN prs_in_range pr ON pr.id = rr.pull_request_id
+       JOIN reviews r ON r.pull_request_id = rr.pull_request_id
+         AND r.author_id = rr.reviewer_id
+       WHERE rr.reviewer_id = $1
+         AND rr.requested_at BETWEEN $2 AND $3
+         AND r.github_submitted_at BETWEEN $2 AND $3
      )
      SELECT
        CASE WHEN (SELECT COUNT(*) FROM prs_in_range) = 0 THEN NULL
             ELSE (SELECT COUNT(*) FROM reviewer_prs)::numeric / (SELECT COUNT(*) FROM prs_in_range)::numeric
        END AS coverage,
-       (SELECT AVG(reviewer_count) FROM person_participation) AS participation
+       CASE WHEN (SELECT COUNT(*) FROM person_requests) = 0 THEN NULL
+            ELSE (SELECT COUNT(*) FROM person_responses)::numeric
+                 / (SELECT COUNT(*) FROM person_requests)::numeric
+       END AS participation
      `,
     params,
   );

--- a/src/lib/dashboard/analytics/reviews.ts
+++ b/src/lib/dashboard/analytics/reviews.ts
@@ -64,18 +64,26 @@ export async function fetchReviewAggregates(
          JOIN pr_scope pr ON pr.id = r.pull_request_id
          WHERE r.github_submitted_at BETWEEN $1 AND $2
        ),
-       participation AS (
-         SELECT
-           pr_scope.id AS pull_request_id,
-           COUNT(DISTINCT r.author_id)
-             FILTER (WHERE r.github_submitted_at BETWEEN $1 AND $2) AS reviewer_count
-         FROM pr_scope
-         LEFT JOIN reviews r ON r.pull_request_id = pr_scope.id
-         GROUP BY pr_scope.id
+       participation_requests AS (
+         SELECT rr.id, rr.pull_request_id, rr.reviewer_id
+         FROM review_requests rr
+         JOIN pr_scope pr ON pr.id = rr.pull_request_id
+         WHERE rr.reviewer_id IS NOT NULL
+           AND rr.requested_at BETWEEN $1 AND $2
+       ),
+       participation_responses AS (
+         SELECT DISTINCT prq.id
+         FROM participation_requests prq
+         JOIN reviews r ON r.pull_request_id = prq.pull_request_id
+           AND r.author_id = prq.reviewer_id
+         WHERE r.github_submitted_at BETWEEN $1 AND $2
        )
        SELECT
          (SELECT COUNT(*) FROM reviews_in_range) AS reviews_completed,
-         (SELECT AVG(COALESCE(participation.reviewer_count, 0)) FROM participation) AS avg_participation
+         CASE WHEN (SELECT COUNT(*) FROM participation_requests) = 0 THEN NULL
+              ELSE (SELECT COUNT(*) FROM participation_responses)::numeric
+                   / (SELECT COUNT(*) FROM participation_requests)::numeric
+         END AS avg_participation
        `,
       params,
     ),

--- a/src/lib/dashboard/people.review-participation.metrics.db.test.ts
+++ b/src/lib/dashboard/people.review-participation.metrics.db.test.ts
@@ -9,8 +9,10 @@ import {
   type DbActor,
   type DbPullRequest,
   type DbReview,
+  type DbReviewRequest,
   upsertPullRequest,
   upsertReview,
+  upsertReviewRequest,
   upsertUser,
 } from "@/lib/db/operations";
 import {
@@ -23,14 +25,15 @@ import {
   shiftHours,
 } from "../../../tests/helpers/dashboard-metrics";
 
-type ParticipationSpec = number[];
+/** [requested, responded] counts per PR */
+type ParticipationSpec = { requested: number; responded: number }[];
 
 describe("people review participation metrics", () => {
   beforeEach(async () => {
     await resetDashboardTables();
   });
 
-  it("averages reviewer counts on participated PRs", async () => {
+  it("computes responded/requested ratio for the person", async () => {
     const { actor, repository } = await seedPersonAndRepo();
     const ranges = buildPeriodRanges(CURRENT_RANGE_START, CURRENT_RANGE_END);
 
@@ -43,31 +46,24 @@ describe("people review participation metrics", () => {
     };
     await upsertUser(prAuthor);
 
-    const extraReviewers: DbActor[] = Array.from({ length: 6 }).map(
-      (_, index) => ({
-        id: `extra-reviewer-${index}`,
-        login: `extra-reviewer-${index}`,
-        name: `Extra Reviewer ${index}`,
-        createdAt: CURRENT_RANGE_START,
-        updatedAt: CURRENT_RANGE_START,
-      }),
-    );
-    await Promise.all(extraReviewers.map((reviewer) => upsertUser(reviewer)));
-
     const specs: Record<(typeof PERIOD_KEYS)[number], ParticipationSpec> = {
-      previous4: [1, 2],
-      previous3: [2],
-      previous2: [3, 2],
-      previous: [4, 3],
-      current: [2, 3, 4],
+      previous4: [{ requested: 1, responded: 1 }, { requested: 1, responded: 0 }],
+      previous3: [{ requested: 1, responded: 1 }],
+      previous2: [{ requested: 1, responded: 1 }, { requested: 1, responded: 1 }],
+      previous: [{ requested: 1, responded: 0 }, { requested: 1, responded: 1 }],
+      current: [
+        { requested: 1, responded: 1 },
+        { requested: 1, responded: 1 },
+        { requested: 1, responded: 0 },
+      ],
     } as const;
 
     let prNumber = 1;
     for (const period of PERIOD_KEYS) {
       const { start } = ranges[period];
-      const counts = specs[period];
-      for (let index = 0; index < counts.length; index += 1) {
-        const reviewerCount = counts[index];
+      const prSpecs = specs[period];
+      for (let index = 0; index < prSpecs.length; index += 1) {
+        const { requested, responded } = prSpecs[index];
         const mergedAt = shiftHours(start, 14 + index * 6);
         const createdAt = shiftHours(mergedAt, -48);
         const prId = `${period}-participation-pr-${index}`;
@@ -89,26 +85,25 @@ describe("people review participation metrics", () => {
         prNumber += 1;
         await upsertPullRequest(pullRequest);
 
-        const reviewers: DbActor[] = [actor];
-        for (let idx = 0; idx < reviewerCount - 1; idx += 1) {
-          reviewers.push(extraReviewers[(index + idx) % extraReviewers.length]);
+        if (requested > 0) {
+          const reviewRequest: DbReviewRequest = {
+            id: `${prId}-rr-actor`,
+            pullRequestId: prId,
+            reviewerId: actor.id,
+            requestedAt: shiftHours(mergedAt, -6),
+            raw: {},
+          };
+          await upsertReviewRequest(reviewRequest);
         }
 
-        for (
-          let reviewerIndex = 0;
-          reviewerIndex < reviewers.length;
-          reviewerIndex += 1
-        ) {
-          const reviewer = reviewers[reviewerIndex];
-          const submittedAt = shiftHours(mergedAt, -2 - reviewerIndex);
-          const state = reviewer.id === actor.id ? "APPROVED" : "COMMENTED";
+        if (responded > 0) {
           const review: DbReview = {
-            id: `${prId}-review-${reviewerIndex}`,
+            id: `${prId}-review-actor`,
             pullRequestId: prId,
-            authorId: reviewer.id,
-            state,
-            submittedAt,
-            raw: { state },
+            authorId: actor.id,
+            state: "APPROVED",
+            submittedAt: shiftHours(mergedAt, -2),
+            raw: { state: "APPROVED" },
           };
           await upsertReview(review);
         }
@@ -129,24 +124,33 @@ describe("people review participation metrics", () => {
     const metric = individual.metrics.reviewParticipation;
     const history = individual.metricHistory.reviewParticipation;
 
-    const averageFor = (values: number[]) =>
-      values.reduce((acc, value) => acc + value, 0) / values.length;
+    const ratioFor = (prSpecs: ParticipationSpec) => {
+      const totalRequested = prSpecs.reduce((sum, s) => sum + s.requested, 0);
+      const totalResponded = prSpecs.reduce((sum, s) => sum + s.responded, 0);
+      return totalRequested > 0 ? totalResponded / totalRequested : null;
+    };
 
-    const expectedHistory = PERIOD_KEYS.map((period) =>
-      averageFor(specs[period]),
-    );
+    const expectedHistory = PERIOD_KEYS.map((period) => ratioFor(specs[period]));
 
-    expect(metric.current).toBeCloseTo(averageFor(specs.current), 5);
-    expect(metric.previous).toBeCloseTo(averageFor(specs.previous), 5);
+    const expectedCurrent = ratioFor(specs.current) ?? 0;
+    const expectedPrevious = ratioFor(specs.previous) ?? 0;
+
+    expect(metric.current).toBeCloseTo(expectedCurrent, 5);
+    expect(metric.previous).toBeCloseTo(expectedPrevious, 5);
     expect(metric.absoluteChange).toBeCloseTo(
-      averageFor(specs.current) - averageFor(specs.previous),
+      expectedCurrent - expectedPrevious,
       5,
     );
 
     expect(history).toHaveLength(PERIOD_KEYS.length);
     history.forEach((entry, index) => {
       expect(entry.period).toBe(PERIOD_KEYS[index]);
-      expect(entry.value ?? Number.NaN).toBeCloseTo(expectedHistory[index], 5);
+      const expected = expectedHistory[index];
+      if (expected == null) {
+        expect(entry.value).toBeNull();
+      } else {
+        expect(entry.value ?? Number.NaN).toBeCloseTo(expected, 5);
+      }
     });
   });
 });

--- a/src/lib/dashboard/people.review-participation.metrics.db.test.ts
+++ b/src/lib/dashboard/people.review-participation.metrics.db.test.ts
@@ -47,10 +47,19 @@ describe("people review participation metrics", () => {
     await upsertUser(prAuthor);
 
     const specs: Record<(typeof PERIOD_KEYS)[number], ParticipationSpec> = {
-      previous4: [{ requested: 1, responded: 1 }, { requested: 1, responded: 0 }],
+      previous4: [
+        { requested: 1, responded: 1 },
+        { requested: 1, responded: 0 },
+      ],
       previous3: [{ requested: 1, responded: 1 }],
-      previous2: [{ requested: 1, responded: 1 }, { requested: 1, responded: 1 }],
-      previous: [{ requested: 1, responded: 0 }, { requested: 1, responded: 1 }],
+      previous2: [
+        { requested: 1, responded: 1 },
+        { requested: 1, responded: 1 },
+      ],
+      previous: [
+        { requested: 1, responded: 0 },
+        { requested: 1, responded: 1 },
+      ],
       current: [
         { requested: 1, responded: 1 },
         { requested: 1, responded: 1 },
@@ -130,7 +139,9 @@ describe("people review participation metrics", () => {
       return totalRequested > 0 ? totalResponded / totalRequested : null;
     };
 
-    const expectedHistory = PERIOD_KEYS.map((period) => ratioFor(specs[period]));
+    const expectedHistory = PERIOD_KEYS.map((period) =>
+      ratioFor(specs[period]),
+    );
 
     const expectedCurrent = ratioFor(specs.current) ?? 0;
     const expectedPrevious = ratioFor(specs.previous) ?? 0;


### PR DESCRIPTION
## Summary

- **Organization view**: replaced the `participation` CTE (which computed `AVG(COUNT(DISTINCT reviewer))` per PR) with a query that joins `review_requests` → `reviews` and computes `responded_count / requested_count`
- **Individual view**: replaced the `participation`/`person_participation` CTEs with a per-person query computing how many of _their_ review requests they actually responded to
- Updated the individual tooltip to match the org tooltip's specificity
- Rewrote both DB test files to seed `review_requests` alongside `reviews` and assert on the correct ratio semantics

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (483 tests)
- [x] `pnpm test:db` passes (147 tests across 57 files)
- [x] `pnpm lint` passes

Closes #422