### PR TITLE
Update CHANGELOG with recent bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fixed date picker calendar showing weekdays off by one (e.g., Wednesday
   dates appearing under Tuesday) due to a mismatch between the Sunday-first
   header and Luxon's Monday-first grid start.
+- Fixed review participation metric computing the inverse ratio (requested
+  over responded) instead of the correct responded-over-requested ratio.
+- Fixed date picker crashing when the Clear button was clicked in custom
+  date-range mode.
 
 ## [0.3.1] - 2026-02-18
 


### PR DESCRIPTION
## Summary

- Add two bug fixes to the Unreleased section that landed after the last CHANGELOG update (25b73ed):
  - reviewParticipation metric computing the inverse ratio (749442d)
  - Date picker Clear button crash in custom mode (9e55779)