### PR TITLE
Exclude tarball artifacts from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,5 @@ Dockerfile.dev
 docker-compose*.yml
 .env*
 backups/
+*.tar
+*.tar.gz


### PR DESCRIPTION
## Summary

Saved docker image tarballs kept alongside the repo (e.g. from `docker save -o github-dashboard-0.3.0.tar`) were leaking into the production image. The builder stage's `COPY . .` pulled them into `/app`, Next.js `output: "standalone"` traced them into `.next/standalone`, and the runner stage baked them in.

Every release carried the previous releases' tarballs, which is why the image grew roughly like this:

| Build | docker save size |
| --- | --- |
| 0.3.0 | 116 MB |
| 0.3.1 | 477 MB (+ 0.1.0/0.2.0 tarballs, ~237 MB) |
| main today | 950 MB (+ 0.3.0/0.3.1 tarballs, ~588 MB more) |

Inspection of the 0.3.1 image confirms it: `docker history` shows the `.next/standalone` COPY layer alone is 431 MB, and `du` on the extracted `/app` directory shows three `github-dashboard-*.tar` files totaling ~348 MB inside the image — on top of a `.next/server` tree of only 13 MB.

The fix is to add `*.tar` and `*.tar.gz` to `.dockerignore` so these archive files never enter the build context in the first place.

## Test plan

- [ ] `docker buildx build -t github-dashboard:test .` from a working tree that contains one or more `*.tar` files in the root
- [ ] `docker save -o /tmp/test.tar github-dashboard:test && ls -lh /tmp/test.tar` — expect ~100 MB range, not ~1 GB
- [ ] `docker run --rm github-dashboard:test ls /app` — confirm no stray `*.tar` files present
- [ ] App still boots end to end (`docker compose up`) and serves as before