### PR TITLE
Remove duplicated picomatch key from pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2306,10 +2306,6 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  picomatch@4.0.5:
-    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
-    engines: {node: '>=12'}
-
   playwright-core@1.61.1:
     resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
@@ -4811,8 +4807,6 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
-
-  picomatch@4.0.5: {}
 
   picomatch@4.0.5: {}
 


### PR DESCRIPTION
CI on `main` has been failing since bf181b6 (#523). `pnpm install --frozen-lockfile` aborts with `ERR_PNPM_BROKEN_LOCKFILE  ... duplicated mapping key (2309:3)`, so the `check` job dies at the install step and `test` / `image-build` never run. The nightly Dependabot Updates jobs fail identically, which is why Dependabot stopped opening PRs.

`077f521` left both `picomatch@4.0.4` and `picomatch@4.0.5` in the lockfile. #523 then rewrote the remaining `4.0.4` to `4.0.5` textually rather than merging it into the existing entry, producing a byte-identical duplicate YAML key in both the `packages:` and `snapshots:` sections.

This removes those 6 duplicate lines. No dependency versions change — `pnpm install --lockfile-only` reproduces the deduplicated file byte-for-byte, and `--frozen-lockfile` then reports the lockfile is up to date.

## Verification

Run locally with Biome pinned to 2.4.9 to match CI:

- `pnpm install --frozen-lockfile` — lockfile up to date
- `biome ci --error-on-warnings .` — 412 files, clean
- `pnpm run lint:tailwind` — clean
- `pnpm run typecheck` — clean
- `markdownlint-cli2` — 0 errors
- `pnpm run test` — 78 files, 483 tests passed

Closes #530