### PR TITLE
Override js-yaml to clear new DoS alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "packageManager": "pnpm@10.30.3",
   "pnpm": {
     "overrides": {
+      "js-yaml": "^5.2.2",
       "postcss": "^8.5.23",
       "sharp": "^0.35.3"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  js-yaml: ^5.2.2
   postcss: ^8.5.23
   sharp: ^0.35.3
 
@@ -1926,8 +1927,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.2.1:
-    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
+  js-yaml@5.2.2:
+    resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -4436,7 +4437,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.2.1:
+  js-yaml@5.2.2:
     dependencies:
       argparse: 2.0.1
 
@@ -4622,7 +4623,7 @@ snapshots:
   markdownlint-cli2@0.23.1:
     dependencies:
       globby: 16.2.1
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       jsonc-parser: 3.3.1
       jsonpointer: 5.0.1
       markdown-it: 14.3.0


### PR DESCRIPTION
Resolves the last open Dependabot alert, [#86](https://github.com/aicers/github-dashboard/security/dependabot/86) (`js-yaml`, high — exponential parsing time in flow collections leads to denial of service). Dependency and lockfile changes only.

Closes #534

## What changed

`js-yaml` is added to the existing `pnpm.overrides` block, moving it from 5.2.1 to 5.2.2.

```json
"pnpm": {
  "overrides": {
    "js-yaml": "^5.2.2",
    "postcss": "^8.5.23",
    "sharp": "^0.35.3"
  }
}
```

## Why this is not a regression from #532

The advisory covering this was published on 2026-07-24 and the alert landed on 2026-07-27, both after #533 was opened. #532 moved `js-yaml` from 4.1.1 to 5.2.1 and correctly closed alerts #69 and #74; this new advisory covers the whole `>= 5.0.0, <= 5.2.1` range, so the version that resolved those earlier alerts became affected in turn.

## Why an override rather than a parent bump

`js-yaml` is a transitive dev dependency reached only through `markdownlint-cli2`, which declares an exact pin (`"js-yaml": "5.2.1"`). `markdownlint-cli2@0.23.1` is the latest release, so there is no newer parent to upgrade to and no range for `pnpm update` to resolve against. This is the same situation as the `postcss` and `sharp` pins handled in #532.

Unlike the `sharp` override, this one is low risk: 5.2.2 is a patch release over the pinned 5.2.1 and does not cross a minor version.

## Verification

- `pnpm install` — clean, no unmet peer dependency warnings
- `pnpm run lint:md` — pass (markdownlint-cli2 0.23.1, 0 issues). This is the meaningful check here, since `markdownlint-cli2` is the sole consumer of `js-yaml` and is what actually exercises the override.
- `pnpm run typecheck` — pass
- `pnpm run test` — pass (78 files, 483 tests)
- `pnpm run build` — pass
- Lockfile audited: `js-yaml` resolves to exactly one version, 5.2.2

## Follow-up

All three overrides are workarounds for upstream exact pins and declared ranges. They should be dropped once `markdownlint-cli2` ships a patched `js-yaml` pin, and once `next` ships patched `postcss` and `sharp` ranges.
