### PR TITLE
Track the current Biome release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Biome CLI
         uses: biomejs/setup-biome@v2
         with:
-          version: 2.4.9
+          version: latest
 
       - name: Run Biome
         run: biome ci --error-on-warnings .

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -35,7 +35,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "suspicious": {
         "noUnknownAtRules": "off"
       }

--- a/scripts/backfill-review-request-requested-at.ts
+++ b/scripts/backfill-review-request-requested-at.ts
@@ -260,7 +260,7 @@ async function fetchReviewRequestsWithEvents(
   const latestEventByReviewer = new Map<string, string>(); // reviewerId -> createdAt
   for (const event of events) {
     const reviewer = event.requestedReviewer;
-    if (!reviewer || reviewer.__typename !== "User") {
+    if (reviewer?.__typename !== "User") {
       continue;
     }
     const existing = latestEventByReviewer.get(reviewer.id);
@@ -275,7 +275,7 @@ async function fetchReviewRequestsWithEvents(
 
   for (const node of reviewRequestNodes) {
     const reviewer = node.requestedReviewer;
-    if (!reviewer || reviewer.__typename !== "User") {
+    if (reviewer?.__typename !== "User") {
       continue;
     }
     const createdAt = latestEventByReviewer.get(reviewer.id) ?? null;

--- a/src/app/api/activity/[id]/project-fields/route.ts
+++ b/src/app/api/activity/[id]/project-fields/route.ts
@@ -165,7 +165,7 @@ function sanitizePayloadValue(key: ProjectFieldKey, raw: unknown) {
 
 async function resolveIssueItem(id: string) {
   const detail = await getActivityItemDetail(id);
-  if (!detail || detail.item.type !== "issue") {
+  if (detail?.item.type !== "issue") {
     return null;
   }
   return detail;

--- a/src/app/api/activity/[id]/status/route.ts
+++ b/src/app/api/activity/[id]/status/route.ts
@@ -30,7 +30,7 @@ function isIssueProjectStatus(value: unknown): value is IssueProjectStatus {
 async function resolveIssueItem(id: string) {
   await ensureSchema();
   const detail = await getActivityItemDetail(id);
-  if (!detail || detail.item.type !== "issue") {
+  if (detail?.item.type !== "issue") {
     return null;
   }
   return detail;

--- a/src/lib/dashboard/analytics.ts
+++ b/src/lib/dashboard/analytics.ts
@@ -96,16 +96,18 @@ export async function getDashboardAnalytics(
   const timeZone = userTimeSettings.timezone;
   const dateTimeFormat = userTimeSettings.dateTimeFormat;
   const weekStart: WeekStart = userTimeSettings.weekStart;
+  const rawExcludedUserIds = config?.excluded_user_ids;
   const excludedUserIds = new Set<string>(
-    Array.isArray(config?.excluded_user_ids)
-      ? (config?.excluded_user_ids as string[]).filter(
+    Array.isArray(rawExcludedUserIds)
+      ? (rawExcludedUserIds as string[]).filter(
           (id) => typeof id === "string" && id.trim().length > 0,
         )
       : [],
   );
+  const rawExcludedRepositoryIds = config?.excluded_repository_ids;
   const excludedRepositoryIds = new Set<string>(
-    Array.isArray(config?.excluded_repository_ids)
-      ? (config?.excluded_repository_ids as string[]).filter(
+    Array.isArray(rawExcludedRepositoryIds)
+      ? (rawExcludedRepositoryIds as string[]).filter(
           (id) => typeof id === "string" && id.trim().length > 0,
         )
       : [],

--- a/src/lib/dashboard/attention.ts
+++ b/src/lib/dashboard/attention.ts
@@ -257,16 +257,18 @@ export async function getAttentionInsights(options?: {
   const organizationHolidaySet = await loadCombinedHolidaySet(
     organizationHolidayCodes,
   );
+  const rawExcludedUserIds = config?.excluded_user_ids;
   const excludedUserIds = new Set<string>(
-    Array.isArray(config?.excluded_user_ids)
-      ? (config?.excluded_user_ids as string[]).filter(
+    Array.isArray(rawExcludedUserIds)
+      ? (rawExcludedUserIds as string[]).filter(
           (id) => typeof id === "string" && id.trim().length > 0,
         )
       : [],
   );
+  const rawExcludedRepositoryIds = config?.excluded_repository_ids;
   const excludedRepositoryIds = new Set<string>(
-    Array.isArray(config?.excluded_repository_ids)
-      ? (config?.excluded_repository_ids as string[]).filter(
+    Array.isArray(rawExcludedRepositoryIds)
+      ? (rawExcludedRepositoryIds as string[]).filter(
           (id) => typeof id === "string" && id.trim().length > 0,
         )
       : [],

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -821,7 +821,7 @@ let ensurePromise: Promise<void> | null = null;
 
 function isPublicSchemaPermissionError(error: unknown) {
   const dbError = error as DatabaseError | null;
-  if (!dbError || dbError.code !== "42501") {
+  if (dbError?.code !== "42501") {
     return false;
   }
 

--- a/src/lib/github/collectors/issues.ts
+++ b/src/lib/github/collectors/issues.ts
@@ -413,7 +413,7 @@ async function fetchDiscussionCommentRepliesConnection(
     },
   );
   const node = data.node;
-  if (!node || node.__typename !== "DiscussionComment") {
+  if (node?.__typename !== "DiscussionComment") {
     return null;
   }
   return node.replies ?? null;

--- a/src/lib/github/collectors/pull-requests.ts
+++ b/src/lib/github/collectors/pull-requests.ts
@@ -80,7 +80,7 @@ async function syncReviewRequestsSnapshot(
 
   const latestEventByReviewer = new Map<string, string>(); // reviewerId -> createdAt
   for (const node of events) {
-    if (!node || node.__typename !== "ReviewRequestedEvent") {
+    if (node?.__typename !== "ReviewRequestedEvent") {
       continue;
     }
     const reviewer = node.requestedReviewer;


### PR DESCRIPTION
Closes #545

Moves the Biome pin from `2.4.9` to `latest` (2.5.7 today), matching the rest of the organisation. Because Biome runs with `--error-on-warnings` here, the bump alone would turn CI red — 2.5.7 reports eleven findings 2.4.9 did not — so the fixes are included.

**`noUnsafeOptionalChaining` ×4** (`analytics.ts`, `attention.ts`). The `Array.isArray(config?.x)` guard already proves the value is an array, but the branch re-evaluated `config?.x`, which the linter cannot narrow through. Each access is hoisted into a local; the `as string[]` cast stays, so inference and behaviour are unchanged.

**`useOptionalChain` ×7**. All `!x || x.y !== "literal"` → `x?.y !== "literal"`. Every subject is an object from a GraphQL or database result and every comparison is against a string literal, so the two forms cover the same inputs.

**`biome.json`** via `biome migrate --write`: schema 2.4.9 → 2.5.7, `linter.rules.recommended` → `preset` (deprecated, removed in Biome 3.x).

**Verification**
- `biome ci --error-on-warnings .` at 2.5.7: exit 0, `Checked 412 files`, no findings, no notices. Before the change: exit 1 with 7 warnings, 4 correctness findings, 2 deprecation notices.
- `pnpm run typecheck` (`tsc --noEmit`): exit 0.